### PR TITLE
Extract DB operations into SQLStore interface

### DIFF
--- a/cmd/hyperboard-api/main.go
+++ b/cmd/hyperboard-api/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/dharmab/hyperboard/internal/api"
 	"github.com/dharmab/hyperboard/internal/db/migrations"
+	"github.com/dharmab/hyperboard/internal/db/store"
 	"github.com/dharmab/hyperboard/internal/middleware/auth"
 	"github.com/dharmab/hyperboard/internal/middleware/logging"
 	s3storage "github.com/dharmab/hyperboard/internal/storage/s3"
@@ -112,7 +113,8 @@ func serveAPI(ctx context.Context, cfg *Config, dsn string) error {
 	defer pool.Close()
 
 	db := bob.NewDB(stdlib.OpenDBFromPool(pool))
-	apiServer := api.NewServer(db, objStorage, cfg.SimilarityThreshold)
+	s := store.NewPostgresSQLStore(db, cfg.SimilarityThreshold)
+	apiServer := api.NewServer(s, objStorage)
 	mux := http.NewServeMux()
 	api.HandlerFromMux(apiServer, mux)
 	mux.HandleFunc("/media/", apiServer.HandleMedia)

--- a/internal/api/health.go
+++ b/internal/api/health.go
@@ -14,12 +14,12 @@ func (s *Server) GetReadiness(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
 	defer cancel()
 
-	if err := s.db.PingContext(ctx); err != nil {
+	if err := s.sqlStore.Ping(ctx); err != nil {
 		respondWithError(w, http.StatusServiceUnavailable, "Database is not ready: %v", err)
 		return
 	}
 
-	if err := s.storage.Ping(ctx); err != nil {
+	if err := s.mediaStore.Ping(ctx); err != nil {
 		respondWithError(w, http.StatusServiceUnavailable, "Object store is not ready: %v", err)
 		return
 	}

--- a/internal/api/notes.go
+++ b/internal/api/notes.go
@@ -1,19 +1,15 @@
 package api
 
 import (
-	"database/sql"
 	"encoding/json"
 	"errors"
 	"net/http"
-	"time"
 
 	"github.com/dharmab/hyperboard/internal/db/models"
+	"github.com/dharmab/hyperboard/internal/db/store"
 	"github.com/dharmab/hyperboard/pkg/types"
 	"github.com/gofrs/uuid/v5"
 	"github.com/rs/zerolog"
-	"github.com/stephenafamo/bob/dialect/psql"
-	"github.com/stephenafamo/bob/dialect/psql/dm"
-	"github.com/stephenafamo/bob/dialect/psql/sm"
 )
 
 func noteFromModel(model *models.Note) types.Note {
@@ -29,9 +25,7 @@ func noteFromModel(model *models.Note) types.Note {
 func (s *Server) GetNotes(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	notes, err := models.Notes.Query(
-		sm.OrderBy(models.Notes.Columns.CreatedAt).Desc(),
-	).All(ctx, s.db)
+	notes, err := s.sqlStore.ListNotes(ctx)
 	if err != nil {
 		respondWithError(w, http.StatusInternalServerError, "Failed to retrieve notes")
 		return
@@ -57,41 +51,22 @@ func (s *Server) CreateNote(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	id, err := uuid.NewV4()
-	if err != nil {
-		respondWithError(w, http.StatusInternalServerError, "Failed to generate note ID")
-		return
-	}
-
-	now := new(time.Now().UTC())
-	model, err := models.Notes.Insert(
-		&models.NoteSetter{
-			ID:        &id,
-			Title:     &body.Title,
-			Content:   &body.Content,
-			CreatedAt: now,
-			UpdatedAt: now,
-		},
-	).One(ctx, s.db)
+	model, err := s.sqlStore.CreateNote(ctx, body.Title, body.Content)
 	if err != nil {
 		respondWithError(w, http.StatusInternalServerError, "Failed to create note")
 		return
 	}
 
-	zerolog.Ctx(ctx).Info().Stringer("note_id", id).Msg("note created")
+	zerolog.Ctx(ctx).Info().Stringer("note_id", model.ID).Msg("note created")
 	respond(w, http.StatusCreated, noteFromModel(model))
 }
 
 func (s *Server) GetNote(w http.ResponseWriter, r *http.Request, id Id) {
 	ctx := r.Context()
 
-	noteID := uuid.UUID(id)
-
-	model, err := models.Notes.Query(
-		sm.Where(models.Notes.Columns.ID.EQ(psql.Arg(noteID))),
-	).One(ctx, s.db)
+	model, err := s.sqlStore.GetNote(ctx, uuid.UUID(id))
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
+		if errors.Is(err, store.ErrNotFound) {
 			respondWithError(w, http.StatusNotFound, "Note not found")
 			return
 		}
@@ -105,41 +80,23 @@ func (s *Server) GetNote(w http.ResponseWriter, r *http.Request, id Id) {
 func (s *Server) PutNote(w http.ResponseWriter, r *http.Request, id Id) {
 	ctx := r.Context()
 
-	noteID := uuid.UUID(id)
-
 	var body PutNoteJSONRequestBody
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		respondWithError(w, http.StatusBadRequest, "Invalid request body")
 		return
 	}
 
-	model, err := models.Notes.Query(
-		sm.Where(models.Notes.Columns.ID.EQ(psql.Arg(noteID))),
-	).One(ctx, s.db)
+	model, err := s.sqlStore.UpdateNote(ctx, uuid.UUID(id), body.Title, body.Content)
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
+		if errors.Is(err, store.ErrNotFound) {
 			respondWithError(w, http.StatusNotFound, "Note not found")
 			return
 		}
-		respondWithError(w, http.StatusInternalServerError, "Failed to retrieve note")
-		return
-	}
-
-	now := new(time.Now().UTC())
-	err = model.Update(ctx, s.db, &models.NoteSetter{
-		Title:     &body.Title,
-		Content:   &body.Content,
-		UpdatedAt: now,
-	})
-	if err != nil {
 		respondWithError(w, http.StatusInternalServerError, "Failed to update note")
 		return
 	}
-	model.Title = body.Title
-	model.Content = body.Content
-	model.UpdatedAt = *now
 
-	zerolog.Ctx(ctx).Info().Stringer("note_id", noteID).Msg("note updated")
+	zerolog.Ctx(ctx).Info().Stringer("note_id", uuid.UUID(id)).Msg("note updated")
 	respond(w, http.StatusOK, noteFromModel(model))
 }
 
@@ -148,22 +105,12 @@ func (s *Server) DeleteNote(w http.ResponseWriter, r *http.Request, id Id) {
 
 	noteID := uuid.UUID(id)
 
-	_, err := models.Notes.Query(
-		sm.Where(models.Notes.Columns.ID.EQ(psql.Arg(noteID))),
-	).One(ctx, s.db)
+	err := s.sqlStore.DeleteNote(ctx, noteID)
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
+		if errors.Is(err, store.ErrNotFound) {
 			respondWithError(w, http.StatusNotFound, "Note not found")
 			return
 		}
-		respondWithError(w, http.StatusInternalServerError, "Failed to retrieve note")
-		return
-	}
-
-	_, err = models.Notes.Delete(
-		dm.Where(models.Notes.Columns.ID.EQ(psql.Arg(noteID))),
-	).Exec(ctx, s.db)
-	if err != nil {
 		respondWithError(w, http.StatusInternalServerError, "Failed to delete note")
 		return
 	}

--- a/internal/api/posts.go
+++ b/internal/api/posts.go
@@ -10,21 +10,16 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strconv"
 	"strings"
 	"time"
 
 	"github.com/dharmab/hyperboard/internal/db/models"
+	"github.com/dharmab/hyperboard/internal/db/store"
 	"github.com/dharmab/hyperboard/internal/media"
 	"github.com/dharmab/hyperboard/internal/search"
 	"github.com/dharmab/hyperboard/pkg/types"
 	"github.com/gofrs/uuid/v5"
 	"github.com/rs/zerolog"
-	"github.com/stephenafamo/bob"
-	"github.com/stephenafamo/bob/dialect/psql"
-	"github.com/stephenafamo/bob/dialect/psql/dialect"
-	"github.com/stephenafamo/bob/dialect/psql/dm"
-	"github.com/stephenafamo/bob/dialect/psql/sm"
 )
 
 func postFromModel(model *models.Post) types.Post {
@@ -135,8 +130,6 @@ func (s *Server) GetPosts(w http.ResponseWriter, r *http.Request, params GetPost
 	ctx := r.Context()
 	logger := *zerolog.Ctx(ctx)
 
-	mods := []bob.Mod[*dialect.SelectQuery]{}
-
 	query := ""
 	if params.Search != nil {
 		query = *params.Search
@@ -153,132 +146,38 @@ func (s *Server) GetPosts(w http.ResponseWriter, r *http.Request, params GetPost
 		Bool("type_audio", searchParams.TypeAudio).
 		Msg("parsed search params")
 
-	for _, tagName := range searchParams.IncludedTags {
-		// Resolve aliases to canonical tag names
-		resolved, err := s.resolveAlias(ctx, s.db, tagName)
-		if err != nil {
-			respondWithError(w, http.StatusInternalServerError, "Failed to resolve tag alias")
-			return
-		}
-		if resolved != tagName {
-			logger.Info().Str("alias", tagName).Str("canonical", resolved).Msg("resolved tag alias")
-		}
-		mods = append(mods, sm.Where(psql.F("EXISTS",
-			psql.Select(
-				sm.Columns(psql.S("1")),
-				sm.From("posts_tags"),
-				sm.InnerJoin("tags").OnEQ(models.PostsTags.Columns.TagID, models.Tags.Columns.ID),
-				sm.Where(psql.And(
-					models.PostsTags.Columns.PostID.EQ(models.Posts.Columns.ID),
-					models.Tags.Columns.Name.EQ(psql.Arg(resolved)),
-				)),
-			),
-		)))
-	}
-
-	for _, tagName := range searchParams.ExcludedTags {
-		resolved, err := s.resolveAlias(ctx, s.db, tagName)
-		if err != nil {
-			respondWithError(w, http.StatusInternalServerError, "Failed to resolve tag alias")
-			return
-		}
-		if resolved != tagName {
-			logger.Info().Str("alias", tagName).Str("canonical", resolved).Msg("resolved exclude tag alias")
-		}
-		mods = append(mods, sm.Where(psql.Not(psql.F("EXISTS",
-			psql.Select(
-				sm.Columns(psql.S("1")),
-				sm.From("posts_tags"),
-				sm.InnerJoin("tags").OnEQ(models.PostsTags.Columns.TagID, models.Tags.Columns.ID),
-				sm.Where(psql.And(
-					models.PostsTags.Columns.PostID.EQ(models.Posts.Columns.ID),
-					models.Tags.Columns.Name.EQ(psql.Arg(resolved)),
-				)),
-			),
-		))))
-	}
-
-	// Apply tagged: filter
-	if searchParams.Tagged != nil {
-		if *searchParams.Tagged {
-			logger.Info().Msg("applying tagged:true filter")
-			mods = append(mods, sm.Where(psql.F("EXISTS",
-				psql.Select(
-					sm.Columns(psql.S("1")),
-					sm.From("posts_tags"),
-					sm.InnerJoin("tags").OnEQ(models.PostsTags.Columns.TagID, models.Tags.Columns.ID),
-					sm.Where(models.PostsTags.Columns.PostID.EQ(models.Posts.Columns.ID)),
-				),
-			)))
-		} else {
-			logger.Info().Msg("applying tagged:false filter")
-			mods = append(mods, sm.Where(psql.Not(psql.F("EXISTS",
-				psql.Select(
-					sm.Columns(psql.S("1")),
-					sm.From("posts_tags"),
-					sm.InnerJoin("tags").OnEQ(models.PostsTags.Columns.TagID, models.Tags.Columns.ID),
-					sm.Where(models.PostsTags.Columns.PostID.EQ(models.Posts.Columns.ID)),
-				),
-			))))
-		}
-	}
-
-	// Apply type: virtual tag filters
-	if searchParams.TypeImage {
-		logger.Info().Msg("applying type:image filter")
-		mods = append(mods, sm.Where(models.Posts.Columns.MimeType.Like(psql.Arg("image/%"))))
-	}
-	if searchParams.TypeVideo {
-		logger.Info().Msg("applying type:video filter")
-		mods = append(mods, sm.Where(models.Posts.Columns.MimeType.Like(psql.Arg("video/%"))))
-	}
-	if searchParams.TypeAudio {
-		logger.Info().Msg("applying type:audio filter")
-		mods = append(mods, sm.Where(models.Posts.Columns.HasAudio.EQ(psql.Arg(true))))
-	}
-
 	limit := parseLimit(params.Limit)
+
+	listParams := store.ListPostsParams{
+		Query: searchParams,
+		Limit: limit,
+	}
 
 	if searchParams.Sort == search.SortRandom {
 		currentSeed := time.Now().Unix() / 21600
-		offset := 0
+		listParams.RandomSeed = &currentSeed
 
 		if params.Cursor != nil && *params.Cursor != "" {
 			var rc randomCursor
 			if err := decodeRandomCursor(*params.Cursor, &rc); err == nil {
 				if rc.Seed == currentSeed {
-					offset = rc.Offset
-					logger.Info().Int64("seed", currentSeed).Int("offset", offset).Msg("resuming random cursor")
+					listParams.RandomOffset = rc.Offset
+					logger.Info().Int64("seed", currentSeed).Int("offset", rc.Offset).Msg("resuming random cursor")
 				} else {
 					logger.Info().Int64("old_seed", rc.Seed).Int64("new_seed", currentSeed).Msg("random window rolled, restarting from offset 0")
 				}
-				// if seed differs, use currentSeed with offset=0 (window rolled)
 			}
 		}
 
-		mods = append(mods,
-			sm.OrderBy(dialect.NewFunction("md5",
-				psql.Cast(models.Posts.Columns.ID, "text").Concat(psql.Arg(strconv.FormatInt(currentSeed, 10))),
-			)),
-			sm.Limit(int64(limit+1)),
-			sm.Offset(int64(offset)),
-		)
-
-		posts, err := models.Posts.Query(mods...).All(ctx, s.db)
+		posts, hasMore, err := s.sqlStore.ListPosts(ctx, listParams)
 		if err != nil {
 			respondWithError(w, http.StatusInternalServerError, "Failed to retrieve posts")
 			return
 		}
 
-		if err := posts.LoadTags(ctx, s.db); err != nil {
-			respondWithError(w, http.StatusInternalServerError, "Failed to load tags")
-			return
-		}
-
 		var nextCursor *string
-		if len(posts) > limit {
-			posts = posts[:limit]
-			rc := randomCursor{Seed: currentSeed, Offset: offset + limit}
+		if hasMore {
+			rc := randomCursor{Seed: currentSeed, Offset: listParams.RandomOffset + limit}
 			encoded := encodeRandomCursor(rc)
 			nextCursor = &encoded
 		}
@@ -291,16 +190,7 @@ func (s *Server) GetPosts(w http.ResponseWriter, r *http.Request, params GetPost
 		return
 	}
 
-	// Determine sort column (default: created_at, newest first)
-	sortCol := models.Posts.Columns.CreatedAt
-	if searchParams.Sort == search.SortUpdatedAt {
-		sortCol = models.Posts.Columns.UpdatedAt
-	}
-	mods = append(mods,
-		sm.OrderBy(sortCol).Desc(),
-		sm.OrderBy(models.Posts.Columns.ID).Desc(),
-	)
-
+	// Deterministic sort with cursor
 	if params.Cursor != nil && *params.Cursor != "" {
 		pc, err := decodePostCursor(*params.Cursor)
 		if err != nil {
@@ -317,32 +207,19 @@ func (s *Server) GetPosts(w http.ResponseWriter, r *http.Request, params GetPost
 			respondWithError(w, http.StatusBadRequest, "Invalid cursor")
 			return
 		}
-		mods = append(mods, sm.Where(psql.Or(
-			sortCol.LT(psql.Arg(ts)),
-			psql.And(
-				sortCol.EQ(psql.Arg(ts)),
-				models.Posts.Columns.ID.LT(psql.Arg(cursorID)),
-			),
-		)))
+		listParams.CursorTime = &ts
+		listParams.CursorID = &cursorID
 	}
 
-	mods = append(mods, sm.Limit(int64(limit+1)))
-
-	posts, err := models.Posts.Query(mods...).All(ctx, s.db)
+	posts, hasMore, err := s.sqlStore.ListPosts(ctx, listParams)
 	if err != nil {
 		respondWithError(w, http.StatusInternalServerError, "Failed to retrieve posts")
 		return
 	}
 
-	if err := posts.LoadTags(ctx, s.db); err != nil {
-		respondWithError(w, http.StatusInternalServerError, "Failed to load tags")
-		return
-	}
-
 	var nextCursor *string
-	if len(posts) > limit {
-		posts = posts[:limit]
-		last := posts[limit-1]
+	if hasMore {
+		last := posts[len(posts)-1]
 		var ts string
 		if searchParams.Sort == search.SortUpdatedAt {
 			ts = last.UpdatedAt.Format(time.RFC3339Nano)
@@ -363,22 +240,13 @@ func (s *Server) GetPosts(w http.ResponseWriter, r *http.Request, params GetPost
 func (s *Server) GetPost(w http.ResponseWriter, r *http.Request, id Id) {
 	ctx := r.Context()
 
-	postID := uuid.UUID(id)
-
-	model, err := models.Posts.Query(
-		sm.Where(models.Posts.Columns.ID.EQ(psql.Arg(postID))),
-	).One(ctx, s.db)
+	model, err := s.sqlStore.GetPost(ctx, uuid.UUID(id))
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
+		if errors.Is(err, store.ErrNotFound) {
 			respondWithError(w, http.StatusNotFound, "Post not found")
 			return
 		}
 		respondWithError(w, http.StatusInternalServerError, "Failed to retrieve post")
-		return
-	}
-
-	if err := model.LoadTags(ctx, s.db); err != nil {
-		respondWithError(w, http.StatusInternalServerError, "Failed to load tags")
 		return
 	}
 
@@ -443,14 +311,12 @@ func (s *Server) UploadPost(w http.ResponseWriter, r *http.Request, params Uploa
 	hash := sha256.Sum256(contentData)
 	hashHex := hex.EncodeToString(hash[:])
 
-	existing, err := models.Posts.Query(
-		sm.Where(models.Posts.Columns.Sha256.EQ(psql.Arg(hashHex))),
-	).One(ctx, s.db)
+	existing, err := s.sqlStore.FindPostBySha256(ctx, hashHex)
 	if err == nil {
 		logger.Info().Stringer("existing_id", existing.ID).Msg("duplicate post detected by sha256")
 		respondWithError(w, http.StatusConflict, "Duplicate of existing post %s", existing.ID)
 		return
-	} else if !errors.Is(err, sql.ErrNoRows) {
+	} else if !errors.Is(err, store.ErrNotFound) {
 		logger.Error().Err(err).Msg("failed to check for duplicate post")
 		respondWithError(w, http.StatusInternalServerError, "Failed to check for duplicate")
 		return
@@ -465,9 +331,9 @@ func (s *Server) UploadPost(w http.ResponseWriter, r *http.Request, params Uploa
 		phashVal = &sql.Null[int64]{V: pHash, Valid: true}
 
 		// Check for visually similar posts (unless force is set).
-		if !force && s.similarityThreshold > 0 {
-			logger.Info().Int("threshold", s.similarityThreshold).Msg("checking for visually similar posts")
-			similar, err := s.findSimilarPosts(ctx, uuid.Nil, pHash, 5)
+		if !force {
+			logger.Info().Msg("checking for visually similar posts")
+			similar, err := s.sqlStore.FindSimilarPosts(ctx, uuid.Nil, pHash, 5)
 			if err != nil {
 				logger.Error().Err(err).Msg("failed to check for similar posts")
 			} else if len(similar) > 0 {
@@ -483,7 +349,7 @@ func (s *Server) UploadPost(w http.ResponseWriter, r *http.Request, params Uploa
 				return
 			}
 			logger.Info().Msg("no similar posts found")
-		} else if force {
+		} else {
 			logger.Info().Msg("skipping similarity check (force=true)")
 		}
 	}
@@ -500,14 +366,14 @@ func (s *Server) UploadPost(w http.ResponseWriter, r *http.Request, params Uploa
 	contentKey := fmt.Sprintf("posts/%s/content.%s", postID, ext)
 	thumbnailKey := fmt.Sprintf("posts/%s/thumbnail.webp", postID)
 
-	contentURL, err := s.storage.Upload(ctx, contentKey, contentData, contentMIME)
+	contentURL, err := s.mediaStore.Upload(ctx, contentKey, contentData, contentMIME)
 	if err != nil {
 		logger.Error().Err(err).Str("key", contentKey).Msg("failed to upload content to storage")
 		respondWithError(w, http.StatusInternalServerError, "Failed to upload content: %v", err)
 		return
 	}
 
-	thumbnailURL, err := s.storage.Upload(ctx, thumbnailKey, thumbnailData, "image/webp")
+	thumbnailURL, err := s.mediaStore.Upload(ctx, thumbnailKey, thumbnailData, "image/webp")
 	if err != nil {
 		logger.Error().Err(err).Str("key", thumbnailKey).Msg("failed to upload thumbnail to storage")
 		respondWithError(w, http.StatusInternalServerError, "Failed to upload thumbnail: %v", err)
@@ -516,19 +382,17 @@ func (s *Server) UploadPost(w http.ResponseWriter, r *http.Request, params Uploa
 
 	id := postID
 	now := new(time.Now().UTC())
-	model, err := models.Posts.Insert(
-		&models.PostSetter{
-			ID:           &id,
-			MimeType:     &contentMIME,
-			ContentURL:   &contentURL,
-			ThumbnailURL: &thumbnailURL,
-			HasAudio:     &hasAudioVal,
-			Sha256:       &hashHex,
-			Phash:        phashVal,
-			CreatedAt:    now,
-			UpdatedAt:    now,
-		},
-	).One(ctx, s.db)
+	model, err := s.sqlStore.CreatePost(ctx, &models.PostSetter{
+		ID:           &id,
+		MimeType:     &contentMIME,
+		ContentURL:   &contentURL,
+		ThumbnailURL: &thumbnailURL,
+		HasAudio:     &hasAudioVal,
+		Sha256:       &hashHex,
+		Phash:        phashVal,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	})
 	if err != nil {
 		logger.Error().Err(err).Msg("failed to insert post into database")
 		respondWithError(w, http.StatusInternalServerError, "Failed to store post: %v", err)
@@ -588,93 +452,20 @@ func (s *Server) PutPost(w http.ResponseWriter, r *http.Request, id Id) {
 		return
 	}
 
-	existingPost, err := models.Posts.Query(
-		sm.Where(models.Posts.Columns.ID.EQ(psql.Arg(postID))),
-	).One(ctx, s.db)
+	now := time.Now().UTC()
+	model, err := s.sqlStore.UpdatePost(ctx, postID, post.Note, post.Tags, now)
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
+		if errors.Is(err, store.ErrNotFound) {
 			respondWithError(w, http.StatusNotFound, "Post not found")
 			return
 		}
-		respondWithError(w, http.StatusInternalServerError, "Failed to retrieve post")
-		return
-	}
-
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		respondWithError(w, http.StatusInternalServerError, "Failed to begin transaction")
-		return
-	}
-	defer func() { _ = tx.Rollback(ctx) }()
-
-	// Only update mutable metadata — storage-controlled fields (MimeType,
-	// ContentURL, ThumbnailURL) are managed by UploadPost/ReplacePostContent.
-	putNow := new(time.Now().UTC())
-	err = existingPost.Update(ctx, tx, &models.PostSetter{
-		Note:      &post.Note,
-		UpdatedAt: putNow,
-	})
-	if err != nil {
 		respondWithError(w, http.StatusInternalServerError, "Failed to update post")
 		return
 	}
 
-	_, err = models.PostsTags.Delete(
-		dm.Where(models.PostsTags.Columns.PostID.EQ(psql.Arg(postID))),
-	).Exec(ctx, tx)
-	if err != nil {
-		respondWithError(w, http.StatusInternalServerError, "Failed to update post tags")
-		return
-	}
-
 	logger := zerolog.Ctx(ctx).With().Stringer("post_id", postID).Logger()
-	for _, tagName := range post.Tags {
-		// Resolve aliases to canonical tag names
-		resolvedName, resolveErr := s.resolveAlias(ctx, tx, tagName)
-		if resolveErr != nil {
-			respondWithError(w, http.StatusInternalServerError, "Failed to resolve tag alias")
-			return
-		}
-		if resolvedName != tagName {
-			logger.Info().Str("alias", tagName).Str("canonical", resolvedName).Msg("resolved tag alias")
-		}
-		// Upsert the tag to avoid TOCTOU race
-		_, err = tx.ExecContext(ctx,
-			"INSERT INTO tags (name, created_at, updated_at) VALUES ($1, $2, $3) ON CONFLICT (name) DO NOTHING",
-			resolvedName, putNow, putNow,
-		)
-		if err != nil {
-			respondWithError(w, http.StatusInternalServerError, "Failed to upsert tag %q", tagName)
-			return
-		}
-		tag, err := models.Tags.Query(
-			sm.Where(models.Tags.Columns.Name.EQ(psql.Arg(resolvedName))),
-		).One(ctx, tx)
-		if err != nil {
-			respondWithError(w, http.StatusInternalServerError, "Failed to retrieve tag %q", tagName)
-			return
-		}
-
-		logger.Info().Str("tag", resolvedName).Msg("attaching tag to post")
-		err = existingPost.AttachTags(ctx, tx, tag)
-		if err != nil {
-			respondWithError(w, http.StatusInternalServerError, "Failed to attach tag")
-			return
-		}
-	}
-
-	if err := existingPost.LoadTags(ctx, tx); err != nil {
-		respondWithError(w, http.StatusInternalServerError, "Failed to load tags")
-		return
-	}
-
-	if err := tx.Commit(ctx); err != nil {
-		respondWithError(w, http.StatusInternalServerError, "Failed to commit transaction")
-		return
-	}
-
 	logger.Info().Int("tag_count", len(post.Tags)).Msg("post updated")
-	respond(w, http.StatusOK, postFromModel(existingPost))
+	respond(w, http.StatusOK, postFromModel(model))
 }
 
 func (s *Server) ReplacePostContent(w http.ResponseWriter, r *http.Request, id Id) {
@@ -682,11 +473,10 @@ func (s *Server) ReplacePostContent(w http.ResponseWriter, r *http.Request, id I
 
 	postID := uuid.UUID(id)
 
-	existingPost, err := models.Posts.Query(
-		sm.Where(models.Posts.Columns.ID.EQ(psql.Arg(postID))),
-	).One(ctx, s.db)
+	// Get existing post to determine old storage keys
+	existingPost, err := s.sqlStore.GetPost(ctx, postID)
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
+		if errors.Is(err, store.ErrNotFound) {
 			respondWithError(w, http.StatusNotFound, "Post not found")
 			return
 		}
@@ -739,27 +529,27 @@ func (s *Server) ReplacePostContent(w http.ResponseWriter, r *http.Request, id I
 	logger := zerolog.Ctx(ctx).With().Stringer("post_id", postID).Logger()
 	if oldContentKey != newContentKey {
 		logger.Info().Str("old_key", oldContentKey).Str("new_key", newContentKey).Msg("mime type changed, deleting old content object")
-		if err := s.storage.Delete(ctx, oldContentKey); err != nil {
+		if err := s.mediaStore.Delete(ctx, oldContentKey); err != nil {
 			logger.Error().Err(err).Str("key", oldContentKey).Msg("failed to delete old content object")
 		}
 	}
 
 	thumbnailKey := storageKeyForThumbnail(postID)
 
-	contentURL, err := s.storage.Upload(ctx, newContentKey, contentData, contentMIME)
+	contentURL, err := s.mediaStore.Upload(ctx, newContentKey, contentData, contentMIME)
 	if err != nil {
 		respondWithError(w, http.StatusInternalServerError, "Failed to upload content")
 		return
 	}
 
-	thumbnailURL, err := s.storage.Upload(ctx, thumbnailKey, thumbnailData, "image/webp")
+	thumbnailURL, err := s.mediaStore.Upload(ctx, thumbnailKey, thumbnailData, "image/webp")
 	if err != nil {
 		respondWithError(w, http.StatusInternalServerError, "Failed to upload thumbnail")
 		return
 	}
 
-	hash := sha256.Sum256(contentData)
-	hashHex := hex.EncodeToString(hash[:])
+	hashArr := sha256.Sum256(contentData)
+	hashHex := hex.EncodeToString(hashArr[:])
 
 	var phashVal *sql.Null[int64]
 	pHash, phashErr := media.DhashFromBytes(thumbnailData)
@@ -769,26 +559,26 @@ func (s *Server) ReplacePostContent(w http.ResponseWriter, r *http.Request, id I
 		phashVal = &sql.Null[int64]{V: pHash, Valid: true}
 	}
 
-	err = existingPost.Update(ctx, s.db, &models.PostSetter{
+	now := new(time.Now().UTC())
+	model, err := s.sqlStore.UpdatePostContent(ctx, postID, &models.PostSetter{
 		MimeType:     &contentMIME,
 		ContentURL:   &contentURL,
 		ThumbnailURL: &thumbnailURL,
 		HasAudio:     &hasAudioVal,
 		Sha256:       &hashHex,
 		Phash:        phashVal,
-		UpdatedAt:    new(time.Now().UTC()),
+		UpdatedAt:    now,
 	})
 	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			respondWithError(w, http.StatusNotFound, "Post not found")
+			return
+		}
 		respondWithError(w, http.StatusInternalServerError, "Failed to update post")
 		return
 	}
 
-	if err = existingPost.LoadTags(ctx, s.db); err != nil {
-		respondWithError(w, http.StatusInternalServerError, "Failed to load tags")
-		return
-	}
-
-	respond(w, http.StatusOK, postFromModel(existingPost))
+	respond(w, http.StatusOK, postFromModel(model))
 }
 
 func (s *Server) ReplacePostThumbnail(w http.ResponseWriter, r *http.Request, id Id) {
@@ -796,11 +586,9 @@ func (s *Server) ReplacePostThumbnail(w http.ResponseWriter, r *http.Request, id
 
 	postID := uuid.UUID(id)
 
-	existingPost, err := models.Posts.Query(
-		sm.Where(models.Posts.Columns.ID.EQ(psql.Arg(postID))),
-	).One(ctx, s.db)
+	_, err := s.sqlStore.GetPost(ctx, postID)
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
+		if errors.Is(err, store.ErrNotFound) {
 			respondWithError(w, http.StatusNotFound, "Post not found")
 			return
 		}
@@ -835,27 +623,24 @@ func (s *Server) ReplacePostThumbnail(w http.ResponseWriter, r *http.Request, id
 	}
 
 	thumbnailKey := storageKeyForThumbnail(postID)
-	thumbnailURL, err := s.storage.Upload(ctx, thumbnailKey, thumbnailData, "image/webp")
+	thumbnailURL, err := s.mediaStore.Upload(ctx, thumbnailKey, thumbnailData, "image/webp")
 	if err != nil {
 		respondWithError(w, http.StatusInternalServerError, "Failed to upload thumbnail")
 		return
 	}
 
-	err = existingPost.Update(ctx, s.db, &models.PostSetter{
-		ThumbnailURL: &thumbnailURL,
-		UpdatedAt:    new(time.Now().UTC()),
-	})
+	now := time.Now().UTC()
+	model, err := s.sqlStore.UpdatePostThumbnail(ctx, postID, thumbnailURL, now)
 	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			respondWithError(w, http.StatusNotFound, "Post not found")
+			return
+		}
 		respondWithError(w, http.StatusInternalServerError, "Failed to update post")
 		return
 	}
 
-	if err := existingPost.LoadTags(ctx, s.db); err != nil {
-		respondWithError(w, http.StatusInternalServerError, "Failed to load tags")
-		return
-	}
-
-	respond(w, http.StatusOK, postFromModel(existingPost))
+	respond(w, http.StatusOK, postFromModel(model))
 }
 
 func (s *Server) DeletePost(w http.ResponseWriter, r *http.Request, id Id) {
@@ -864,11 +649,9 @@ func (s *Server) DeletePost(w http.ResponseWriter, r *http.Request, id Id) {
 	postID := uuid.UUID(id)
 
 	// Fetch the post first to get storage keys for cleanup.
-	post, err := models.Posts.Query(
-		sm.Where(models.Posts.Columns.ID.EQ(psql.Arg(postID))),
-	).One(ctx, s.db)
+	post, err := s.sqlStore.GetPost(ctx, postID)
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
+		if errors.Is(err, store.ErrNotFound) {
 			respondWithError(w, http.StatusNotFound, "Post not found")
 			return
 		}
@@ -879,20 +662,18 @@ func (s *Server) DeletePost(w http.ResponseWriter, r *http.Request, id Id) {
 	logger := zerolog.Ctx(ctx).With().Stringer("post_id", postID).Logger()
 	contentKey := storageKeyForContent(postID, post.MimeType)
 	thumbnailKey := storageKeyForThumbnail(postID)
-	if err := s.storage.Delete(ctx, contentKey); err != nil {
+	if err := s.mediaStore.Delete(ctx, contentKey); err != nil {
 		logger.Error().Err(err).Str("key", contentKey).Msg("failed to delete content object")
 		respondWithError(w, http.StatusInternalServerError, "Failed to delete post content from storage")
 		return
 	}
-	if err := s.storage.Delete(ctx, thumbnailKey); err != nil {
+	if err := s.mediaStore.Delete(ctx, thumbnailKey); err != nil {
 		logger.Error().Err(err).Str("key", thumbnailKey).Msg("failed to delete thumbnail object")
 		respondWithError(w, http.StatusInternalServerError, "Failed to delete post thumbnail from storage")
 		return
 	}
 
-	_, err = models.Posts.Delete(
-		dm.Where(models.Posts.Columns.ID.EQ(psql.Arg(postID))),
-	).Exec(ctx, s.db)
+	_, err = s.sqlStore.DeletePost(ctx, postID)
 	if err != nil {
 		respondWithError(w, http.StatusInternalServerError, "Failed to delete post")
 		return

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -6,24 +6,22 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/dharmab/hyperboard/internal/db/store"
 	"github.com/dharmab/hyperboard/internal/storage"
 	"github.com/rs/zerolog/log"
-	"github.com/stephenafamo/bob"
 )
 
 type Server struct {
-	db                  bob.DB
-	storage             storage.Storage
-	similarityThreshold int
+	sqlStore   store.SQLStore
+	mediaStore storage.MediaStore
 }
 
 var _ ServerInterface = &Server{}
 
-func NewServer(db bob.DB, storage storage.Storage, similarityThreshold int) *Server {
+func NewServer(sqlStore store.SQLStore, mediaStore storage.MediaStore) *Server {
 	return &Server{
-		db:                  db,
-		storage:             storage,
-		similarityThreshold: similarityThreshold,
+		sqlStore:   sqlStore,
+		mediaStore: mediaStore,
 	}
 }
 
@@ -39,7 +37,7 @@ func (s *Server) HandleMedia(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	obj, err := s.storage.Download(r.Context(), key)
+	obj, err := s.mediaStore.Download(r.Context(), key)
 	if err != nil {
 		log.Error().Err(err).Str("key", key).Msg("failed to download media")
 		http.Error(w, "Media not found", http.StatusNotFound)

--- a/internal/api/similar.go
+++ b/internal/api/similar.go
@@ -1,18 +1,12 @@
 package api
 
 import (
-	"context"
-	"database/sql"
 	"errors"
 	"net/http"
 
-	"github.com/dharmab/hyperboard/internal/db/models"
+	"github.com/dharmab/hyperboard/internal/db/store"
 	"github.com/dharmab/hyperboard/pkg/types"
 	"github.com/gofrs/uuid/v5"
-	"github.com/stephenafamo/bob"
-	"github.com/stephenafamo/bob/dialect/psql"
-	"github.com/stephenafamo/bob/dialect/psql/dialect"
-	"github.com/stephenafamo/bob/dialect/psql/sm"
 )
 
 // SimilarPostsResponse is returned when an upload is blocked due to
@@ -23,36 +17,14 @@ type SimilarPostsResponse struct {
 	Similar []types.Post `json:"similar"`
 }
 
-// findSimilarPosts returns posts whose perceptual hash is within the
-// configured Hamming distance threshold of the given hash.
-func (s *Server) findSimilarPosts(ctx context.Context, excludeID uuid.UUID, pHash int64, limit int) (models.PostSlice, error) {
-	phashHamming := dialect.NewFunction("bit_count",
-		psql.Cast(psql.Group(models.Posts.Columns.Phash.OP("#", psql.Arg(pHash))), "bit(64)"),
-	)
-	mods := []bob.Mod[*dialect.SelectQuery]{
-		sm.Where(models.Posts.Columns.Phash.IsNotNull()),
-		sm.Where(phashHamming.LTE(psql.Arg(s.similarityThreshold))),
-		sm.OrderBy(phashHamming),
-		sm.Limit(int64(limit)),
-	}
-
-	if excludeID != uuid.Nil {
-		mods = append(mods, sm.Where(models.Posts.Columns.ID.NE(psql.Arg(excludeID))))
-	}
-
-	return models.Posts.Query(mods...).All(ctx, s.db)
-}
-
 func (s *Server) GetSimilarPosts(w http.ResponseWriter, r *http.Request, id Id, params GetSimilarPostsParams) {
 	ctx := r.Context()
 
 	postID := uuid.UUID(id)
 
-	post, err := models.Posts.Query(
-		sm.Where(models.Posts.Columns.ID.EQ(psql.Arg(postID))),
-	).One(ctx, s.db)
+	post, err := s.sqlStore.GetPost(ctx, postID)
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
+		if errors.Is(err, store.ErrNotFound) {
 			respondWithError(w, http.StatusNotFound, "Post not found")
 			return
 		}
@@ -67,14 +39,9 @@ func (s *Server) GetSimilarPosts(w http.ResponseWriter, r *http.Request, id Id, 
 
 	limit := parseLimit(params.Limit)
 
-	similar, err := s.findSimilarPosts(ctx, postID, post.Phash.V, limit)
+	similar, err := s.sqlStore.FindSimilarPosts(ctx, postID, post.Phash.V, limit)
 	if err != nil {
 		respondWithError(w, http.StatusInternalServerError, "Failed to find similar posts")
-		return
-	}
-
-	if err := similar.LoadTags(ctx, s.db); err != nil {
-		respondWithError(w, http.StatusInternalServerError, "Failed to load tags")
 		return
 	}
 

--- a/internal/api/tag_categories.go
+++ b/internal/api/tag_categories.go
@@ -1,24 +1,16 @@
 package api
 
 import (
-	"context"
-	"database/sql"
 	"encoding/json"
 	"errors"
 	"net/http"
-	"strconv"
-	"strings"
 	"time"
 
 	"github.com/dharmab/hyperboard/internal/db/models"
+	"github.com/dharmab/hyperboard/internal/db/store"
 	"github.com/dharmab/hyperboard/pkg/types"
 	"github.com/gofrs/uuid/v5"
 	"github.com/rs/zerolog"
-	"github.com/stephenafamo/bob"
-	"github.com/stephenafamo/bob/dialect/psql"
-	"github.com/stephenafamo/bob/dialect/psql/dialect"
-	"github.com/stephenafamo/bob/dialect/psql/dm"
-	"github.com/stephenafamo/bob/dialect/psql/sm"
 )
 
 func tagCategoryFromModel(model *models.TagCategory) types.TagCategory {
@@ -31,95 +23,45 @@ func tagCategoryFromModel(model *models.TagCategory) types.TagCategory {
 	}
 }
 
-// getTagCountsByCategory returns the number of tags in each category, keyed by category ID.
-func (s *Server) getTagCountsByCategory(ctx context.Context, categoryIDs []uuid.UUID) (map[uuid.UUID]int, error) {
-	if len(categoryIDs) == 0 {
-		return map[uuid.UUID]int{}, nil
-	}
-
-	args := make([]any, len(categoryIDs))
-	var placeholders strings.Builder
-	for i, id := range categoryIDs {
-		if i > 0 {
-			placeholders.WriteString(", ")
-		}
-		placeholders.WriteString("$" + strconv.Itoa(i+1))
-		args[i] = id
-	}
-
-	rows, err := s.db.QueryContext(ctx,
-		"SELECT tag_category_id, COUNT(*) FROM tags WHERE tag_category_id IN ("+placeholders.String()+") GROUP BY tag_category_id",
-		args...,
-	)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = rows.Close() }()
-
-	counts := make(map[uuid.UUID]int)
-	for rows.Next() {
-		var catID uuid.UUID
-		var count int
-		if err := rows.Scan(&catID, &count); err != nil {
-			return nil, err
-		}
-		counts[catID] = count
-	}
-	return counts, rows.Err()
-}
-
 func (s *Server) GetTagCategories(w http.ResponseWriter, r *http.Request, params GetTagCategoriesParams) {
 	ctx := r.Context()
 
-	// Ordering
-	mods := []bob.Mod[*dialect.SelectQuery]{
-		sm.OrderBy(models.TagCategories.Columns.Name).Asc(),
-	}
-
-	// Cursor
+	var decodedCursor *string
 	if params.Cursor != nil && *params.Cursor != "" {
-		decodedName, err := deobfuscateCursor(*params.Cursor)
+		decoded, err := deobfuscateCursor(*params.Cursor)
 		if err != nil {
 			respondWithError(w, http.StatusBadRequest, "Invalid cursor")
 			return
 		}
-		mods = append(mods, sm.Where(models.TagCategories.Columns.Name.GT(psql.Arg(decodedName))))
+		decodedCursor = &decoded
 	}
 
-	// Limit
 	limit := parseLimit(params.Limit)
-	mods = append(mods, sm.Limit(int64(limit+1)))
 
-	// Query
-	categories, err := models.TagCategories.Query(mods...).All(ctx, s.db)
+	categories, hasMore, err := s.sqlStore.ListTagCategories(ctx, decodedCursor, limit)
 	if err != nil {
 		respondWithError(w, http.StatusInternalServerError, "Failed to retrieve tag categories")
 		return
 	}
 
 	// Collect IDs for the current page
-	pageSize := min(len(categories), limit)
-	catIDs := make([]uuid.UUID, pageSize)
-	for i := range pageSize {
+	catIDs := make([]uuid.UUID, len(categories))
+	for i := range categories {
 		catIDs[i] = categories[i].ID
 	}
 
-	// Query tag counts server-side
-	tagCounts, err := s.getTagCountsByCategory(ctx, catIDs)
+	tagCounts, err := s.sqlStore.GetTagCountsByCategory(ctx, catIDs)
 	if err != nil {
 		respondWithError(w, http.StatusInternalServerError, "Failed to retrieve tag counts")
 		return
 	}
 
-	// Check if there's content after the limit
-	hasMore, nextCursor := paginate(len(categories), limit, func() string {
-		return categories[limit-1].Name
-	})
+	var nextCursor *string
 	if hasMore {
-		categories = categories[:limit]
+		encoded := obfuscateCursor(categories[len(categories)-1].Name)
+		nextCursor = &encoded
 	}
 
-	// Response
 	items := make([]types.TagCategory, 0, len(categories))
 	for _, category := range categories {
 		cat := tagCategoryFromModel(category)
@@ -140,11 +82,9 @@ func (s *Server) GetTagCategories(w http.ResponseWriter, r *http.Request, params
 
 func (s *Server) GetTagCategory(w http.ResponseWriter, r *http.Request, name TagCategory) {
 	ctx := r.Context()
-	model, err := models.TagCategories.Query(
-		sm.Where(models.TagCategories.Columns.Name.EQ(psql.Arg(name))),
-	).One(ctx, s.db)
+	model, err := s.sqlStore.GetTagCategory(ctx, name)
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
+		if errors.Is(err, store.ErrNotFound) {
 			respondWithError(w, http.StatusNotFound, "Tag category %q not found", name)
 			return
 		}
@@ -167,67 +107,46 @@ func (s *Server) PutTagCategory(w http.ResponseWriter, r *http.Request, name Tag
 		return
 	}
 
-	existing, err := models.TagCategories.Query(
-		sm.Where(models.TagCategories.Columns.Name.EQ(psql.Arg(name))),
-	).One(ctx, s.db)
-	if err != nil && !errors.Is(err, sql.ErrNoRows) {
-		respondWithError(w, http.StatusInternalServerError, "Failed to retrieve tag category")
-		return
-	}
-
-	logger := zerolog.Ctx(ctx).With().Str("category", name).Logger()
-	if existing != nil {
-		logger.Info().Str("new_name", req.Name).Msg("updating existing tag category")
-		// Update (supports rename)
-		now := new(time.Now().UTC())
-		err = existing.Update(ctx, s.db, &models.TagCategorySetter{
-			Name:        &req.Name,
-			Description: &req.Description,
-			Color:       &req.Color,
-			UpdatedAt:   now,
-		})
-		if err != nil {
-			respondWithError(w, http.StatusInternalServerError, "Failed to update tag category")
-			return
-		}
-		existing.Name = req.Name
-		existing.Description = req.Description
-		existing.Color = req.Color
-		existing.UpdatedAt = *now
-		logger.Info().Msg("tag category updated")
-		respond(w, http.StatusOK, tagCategoryFromModel(existing))
-	} else {
-		if req.Name != name {
+	// For creates, name in body must match URL
+	if req.Name != name {
+		// Check if this is an update (existing category) - if so, rename is allowed
+		_, err := s.sqlStore.GetTagCategory(ctx, name)
+		if errors.Is(err, store.ErrNotFound) {
 			respondWithError(w, http.StatusBadRequest, "Tag category name mismatch: got %q in body but %q in URL", req.Name, name)
 			return
 		}
-		logger.Info().Msg("creating new tag category")
-		now := new(time.Now().UTC())
-		inserted, err := models.TagCategories.Insert(
-			&models.TagCategorySetter{
-				Name:        &req.Name,
-				Description: &req.Description,
-				Color:       &req.Color,
-				CreatedAt:   now,
-				UpdatedAt:   now,
-			},
-		).One(ctx, s.db)
 		if err != nil {
-			respondWithError(w, http.StatusInternalServerError, "Failed to create tag category")
+			respondWithError(w, http.StatusInternalServerError, "Failed to retrieve tag category")
 			return
 		}
+	}
+
+	logger := zerolog.Ctx(ctx).With().Str("category", name).Logger()
+	now := time.Now().UTC()
+	model, isCreate, err := s.sqlStore.UpsertTagCategory(ctx, name, store.TagCategoryInput{
+		Name:        req.Name,
+		Description: req.Description,
+		Color:       req.Color,
+	}, now)
+	if err != nil {
+		respondWithError(w, http.StatusInternalServerError, "Failed to save tag category")
+		return
+	}
+
+	if isCreate {
 		logger.Info().Msg("tag category created")
-		respond(w, http.StatusCreated, tagCategoryFromModel(inserted))
+		respond(w, http.StatusCreated, tagCategoryFromModel(model))
+	} else {
+		logger.Info().Str("new_name", req.Name).Msg("tag category updated")
+		respond(w, http.StatusOK, tagCategoryFromModel(model))
 	}
 }
 
 func (s *Server) DeleteTagCategory(w http.ResponseWriter, r *http.Request, name TagCategory) {
 	ctx := r.Context()
-	_, err := models.TagCategories.Delete(
-		dm.Where(models.TagCategories.Columns.Name.EQ(psql.Arg(name))),
-	).Exec(ctx, s.db)
+	err := s.sqlStore.DeleteTagCategory(ctx, name)
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
+		if errors.Is(err, store.ErrNotFound) {
 			respondWithError(w, http.StatusNotFound, "Tag category %q not found", name)
 			return
 		}

--- a/internal/api/tags.go
+++ b/internal/api/tags.go
@@ -1,26 +1,18 @@
 package api
 
 import (
-	"context"
 	"database/sql"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
-	"strconv"
-	"strings"
 	"time"
 	"unicode"
 
 	"github.com/dharmab/hyperboard/internal/db/models"
+	"github.com/dharmab/hyperboard/internal/db/store"
 	"github.com/dharmab/hyperboard/pkg/types"
 	"github.com/gofrs/uuid/v5"
 	"github.com/rs/zerolog"
-	"github.com/stephenafamo/bob"
-	"github.com/stephenafamo/bob/dialect/psql"
-	"github.com/stephenafamo/bob/dialect/psql/dialect"
-	"github.com/stephenafamo/bob/dialect/psql/dm"
-	"github.com/stephenafamo/bob/dialect/psql/sm"
 )
 
 // isValidName reports whether name begins with a unicode letter or digit,
@@ -57,172 +49,49 @@ func tagFromModel(model *models.Tag) types.Tag {
 	return tag
 }
 
-// getTagAliases returns a map from tag ID to its list of aliases.
-func (s *Server) getTagAliases(ctx context.Context, tagIDs ...uuid.UUID) (map[uuid.UUID][]string, error) {
-	if len(tagIDs) == 0 {
-		return map[uuid.UUID][]string{}, nil
-	}
-
-	args := make([]any, len(tagIDs))
-	var placeholders strings.Builder
-	for i, id := range tagIDs {
-		if i > 0 {
-			placeholders.WriteString(", ")
-		}
-		placeholders.WriteString("$" + strconv.Itoa(i+1))
-		args[i] = id
-	}
-
-	rows, err := s.db.QueryContext(ctx,
-		"SELECT tag_id, alias_name FROM tag_aliases WHERE tag_id IN ("+placeholders.String()+") ORDER BY alias_name",
-		args...,
-	)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = rows.Close() }()
-
-	result := make(map[uuid.UUID][]string)
-	for rows.Next() {
-		var tagID uuid.UUID
-		var alias string
-		if err := rows.Scan(&tagID, &alias); err != nil {
-			return nil, err
-		}
-		result[tagID] = append(result[tagID], alias)
-	}
-	return result, rows.Err()
-}
-
-// setTagAliases replaces all aliases for a tag with the given list.
-// Returns an error if any alias conflicts with an existing tag name.
-func (s *Server) setTagAliases(ctx context.Context, exec bob.Executor, tagID uuid.UUID, aliases []string) error {
-	// Check that no alias conflicts with an existing tag name
-	for _, alias := range aliases {
-		if alias == "" {
-			continue
-		}
-		rows, err := exec.QueryContext(ctx, "SELECT COUNT(*) FROM tags WHERE name = $1", alias)
-		if err != nil {
-			return err
-		}
-		var count int
-		if rows.Next() {
-			err = rows.Scan(&count)
-		}
-		closeErr := rows.Close()
-		if err != nil {
-			return err
-		}
-		if closeErr != nil {
-			return closeErr
-		}
-		if count > 0 {
-			return fmt.Errorf("alias %q conflicts with an existing tag name", alias)
-		}
-	}
-
-	_, err := exec.ExecContext(ctx, "DELETE FROM tag_aliases WHERE tag_id = $1", tagID)
-	if err != nil {
-		return err
-	}
-	for _, alias := range aliases {
-		if alias == "" {
-			continue
-		}
-		_, err := exec.ExecContext(ctx,
-			"INSERT INTO tag_aliases (tag_id, alias_name) VALUES ($1, $2)",
-			tagID, alias,
-		)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// resolveAlias looks up an alias and returns the canonical tag name.
-// If the name is not an alias, it is returned as-is.
-func (s *Server) resolveAlias(ctx context.Context, exec bob.Executor, name string) (string, error) {
-	rows, err := exec.QueryContext(ctx,
-		"SELECT t.name FROM tags t JOIN tag_aliases ta ON t.id = ta.tag_id WHERE ta.alias_name = $1",
-		name,
-	)
-	if err != nil {
-		return "", err
-	}
-	defer func() { _ = rows.Close() }()
-	if rows.Next() {
-		var canonical string
-		if err := rows.Scan(&canonical); err != nil {
-			return "", err
-		}
-		return canonical, rows.Err()
-	}
-	return name, rows.Err()
-}
-
 func (s *Server) GetTags(w http.ResponseWriter, r *http.Request, params GetTagsParams) {
 	ctx := r.Context()
 
-	// Ordering
-	mods := []bob.Mod[*dialect.SelectQuery]{
-		sm.OrderBy(models.Tags.Columns.Name).Asc(),
-	}
-
-	// Cursor
+	var decodedCursor *string
 	if params.Cursor != nil && *params.Cursor != "" {
-		decodedName, err := deobfuscateCursor(*params.Cursor)
+		decoded, err := deobfuscateCursor(*params.Cursor)
 		if err != nil {
 			respondWithError(w, http.StatusBadRequest, "Invalid cursor")
 			return
 		}
-		mods = append(mods, sm.Where(models.Tags.Columns.Name.GT(psql.Arg(decodedName))))
+		decodedCursor = &decoded
 	}
 
-	// Limit
 	limit := parseLimit(params.Limit)
-	mods = append(mods, sm.Limit(int64(limit+1)))
 
-	tags, err := models.Tags.Query(mods...).All(ctx, s.db)
+	tags, hasMore, err := s.sqlStore.ListTags(ctx, decodedCursor, limit)
 	if err != nil {
 		respondWithError(w, http.StatusInternalServerError, "Failed to retrieve tags")
 		return
 	}
 
-	// Load tag category relationships
-	if err := tags.LoadTagCategory(ctx, s.db); err != nil {
-		respondWithError(w, http.StatusInternalServerError, "Failed to load tag categories")
-		return
-	}
-
-	// Collect tag IDs for the current page only
-	pageSize := min(len(tags), limit)
-	tagIDs := make([]uuid.UUID, pageSize)
-	for i := range pageSize {
+	// Collect tag IDs for the current page
+	tagIDs := make([]uuid.UUID, len(tags))
+	for i := range tags {
 		tagIDs[i] = tags[i].ID
 	}
 
-	// Query post counts only for the tags on this page
-	postCounts, err := s.getTagPostCounts(ctx, tagIDs)
+	postCounts, err := s.sqlStore.GetTagPostCounts(ctx, tagIDs)
 	if err != nil {
 		respondWithError(w, http.StatusInternalServerError, "Failed to retrieve post counts")
 		return
 	}
 
-	// Query aliases only for the tags on this page
-	aliasMap, err := s.getTagAliases(ctx, tagIDs...)
+	aliasMap, err := s.sqlStore.GetTagAliases(ctx, tagIDs...)
 	if err != nil {
 		respondWithError(w, http.StatusInternalServerError, "Failed to retrieve tag aliases")
 		return
 	}
 
-	// Check if there's content after the limit
-	hasMore, nextCursor := paginate(len(tags), limit, func() string {
-		return tags[limit-1].Name
-	})
+	var nextCursor *string
 	if hasMore {
-		tags = tags[:limit]
+		encoded := obfuscateCursor(tags[len(tags)-1].Name)
+		nextCursor = &encoded
 	}
 
 	items := make([]types.Tag, 0, len(tags))
@@ -253,11 +122,9 @@ func (s *Server) GetTag(w http.ResponseWriter, r *http.Request, name Tag) {
 		respondWithError(w, http.StatusBadRequest, "Tag name cannot be empty")
 		return
 	}
-	model, err := models.Tags.Query(
-		sm.Where(models.Tags.Columns.Name.EQ(psql.Arg(name))),
-	).One(ctx, s.db)
+	model, err := s.sqlStore.GetTag(ctx, name)
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
+		if errors.Is(err, store.ErrNotFound) {
 			respondWithError(w, http.StatusNotFound, "Tag %q not found", name)
 			return
 		}
@@ -265,16 +132,9 @@ func (s *Server) GetTag(w http.ResponseWriter, r *http.Request, name Tag) {
 		return
 	}
 
-	if model.TagCategoryID.Valid {
-		if err := model.LoadTagCategory(ctx, s.db); err != nil {
-			respondWithError(w, http.StatusInternalServerError, "Failed to load tag category")
-			return
-		}
-	}
-
 	tagResp := tagFromModel(model)
 
-	aliasMap, err := s.getTagAliases(ctx, model.ID)
+	aliasMap, err := s.sqlStore.GetTagAliases(ctx, model.ID)
 	if err != nil {
 		respondWithError(w, http.StatusInternalServerError, "Failed to load tag aliases")
 		return
@@ -305,16 +165,27 @@ func (s *Server) PutTag(w http.ResponseWriter, r *http.Request, name Tag) {
 		return
 	}
 
+	// For creates, name in body must match URL
+	if tag.Name != name {
+		_, err := s.sqlStore.GetTag(ctx, name)
+		if errors.Is(err, store.ErrNotFound) {
+			respondWithError(w, http.StatusBadRequest, "Tag name mismatch: got %q in body but %q in URL", tag.Name, name)
+			return
+		}
+		if err != nil {
+			respondWithError(w, http.StatusInternalServerError, "Failed to retrieve tag")
+			return
+		}
+	}
+
 	// Resolve tag category ID if category name is provided
 	logger := zerolog.Ctx(ctx).With().Str("tag", name).Logger()
 	var tagCategoryID sql.Null[uuid.UUID]
 	if tag.Category != nil && *tag.Category != "" {
 		logger.Info().Str("category", *tag.Category).Msg("resolving tag category")
-		category, err := models.TagCategories.Query(
-			sm.Where(models.TagCategories.Columns.Name.EQ(psql.Arg(*tag.Category))),
-		).One(ctx, s.db)
+		category, err := s.sqlStore.GetTagCategory(ctx, *tag.Category)
 		if err != nil {
-			if errors.Is(err, sql.ErrNoRows) {
+			if errors.Is(err, store.ErrNotFound) {
 				respondWithError(w, http.StatusBadRequest, "Tag category %q not found", *tag.Category)
 				return
 			}
@@ -324,88 +195,31 @@ func (s *Server) PutTag(w http.ResponseWriter, r *http.Request, name Tag) {
 		tagCategoryID = sql.Null[uuid.UUID]{V: category.ID, Valid: true}
 	}
 
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		respondWithError(w, http.StatusInternalServerError, "Failed to begin transaction")
-		return
-	}
-	defer func() { _ = tx.Rollback(ctx) }()
-
-	existing, err := models.Tags.Query(
-		sm.Where(models.Tags.Columns.Name.EQ(psql.Arg(name))),
-	).One(ctx, tx)
-	if err != nil && !errors.Is(err, sql.ErrNoRows) {
-		respondWithError(w, http.StatusInternalServerError, "Failed to retrieve tag")
-		return
-	}
-
-	now := new(time.Now().UTC())
-	var resultModel *models.Tag
-	if existing != nil {
-		logger.Info().Str("new_name", tag.Name).Msg("updating existing tag")
-		// Update (supports rename)
-		err = existing.Update(ctx, tx, &models.TagSetter{
-			Name:          &tag.Name,
-			Description:   &tag.Description,
-			TagCategoryID: &tagCategoryID,
-			UpdatedAt:     now,
-		})
-		if err != nil {
-			respondWithError(w, http.StatusInternalServerError, "Failed to update tag")
-			return
-		}
-		existing.Name = tag.Name
-		existing.Description = tag.Description
-		existing.TagCategoryID = tagCategoryID
-		resultModel = existing
-		logger.Info().Msg("tag updated")
-	} else {
-		if tag.Name != name {
-			respondWithError(w, http.StatusBadRequest, "Tag name mismatch: got %q in body but %q in URL", tag.Name, name)
-			return
-		}
-		logger.Info().Msg("creating new tag")
-		resultModel, err = models.Tags.Insert(
-			&models.TagSetter{
-				Name:          &tag.Name,
-				Description:   &tag.Description,
-				TagCategoryID: &tagCategoryID,
-				CreatedAt:     now,
-				UpdatedAt:     now,
-			},
-		).One(ctx, tx)
-		if err != nil {
-			respondWithError(w, http.StatusInternalServerError, "Failed to create tag")
-			return
-		}
-		logger.Info().Msg("tag created")
-	}
-
-	// Update aliases
 	var aliases []string
 	if tag.Aliases != nil {
 		aliases = *tag.Aliases
 	}
-	if err := s.setTagAliases(ctx, tx, resultModel.ID, aliases); err != nil {
-		respondWithError(w, http.StatusInternalServerError, "Failed to update tag aliases")
-		return
-	}
 
-	if err := tx.Commit(ctx); err != nil {
-		respondWithError(w, http.StatusInternalServerError, "Failed to commit transaction")
-		return
-	}
-
-	if resultModel.TagCategoryID.Valid {
-		if err := resultModel.LoadTagCategory(ctx, s.db); err != nil {
-			respondWithError(w, http.StatusInternalServerError, "Failed to load tag category")
+	now := time.Now().UTC()
+	resultModel, isCreate, err := s.sqlStore.UpsertTag(ctx, name, store.TagInput{
+		Name:          tag.Name,
+		Description:   tag.Description,
+		Category:      tag.Category,
+		Aliases:       aliases,
+		TagCategoryID: tagCategoryID,
+	}, now)
+	if err != nil {
+		if errors.Is(err, store.ErrAliasConflict) {
+			respondWithError(w, http.StatusInternalServerError, "Failed to update tag aliases")
 			return
 		}
+		respondWithError(w, http.StatusInternalServerError, "Failed to save tag")
+		return
 	}
 
 	tagResp := tagFromModel(resultModel)
 
-	aliasMap, err := s.getTagAliases(ctx, resultModel.ID)
+	aliasMap, err := s.sqlStore.GetTagAliases(ctx, resultModel.ID)
 	if err != nil {
 		respondWithError(w, http.StatusInternalServerError, "Failed to load tag aliases")
 		return
@@ -415,47 +229,13 @@ func (s *Server) PutTag(w http.ResponseWriter, r *http.Request, name Tag) {
 	}
 
 	status := http.StatusOK
-	if existing == nil {
+	if isCreate {
 		status = http.StatusCreated
+		logger.Info().Msg("tag created")
+	} else {
+		logger.Info().Str("new_name", tag.Name).Msg("tag updated")
 	}
 	respond(w, status, tagResp)
-}
-
-// getTagPostCounts returns post counts for the given tag IDs.
-func (s *Server) getTagPostCounts(ctx context.Context, tagIDs []uuid.UUID) (map[uuid.UUID]int, error) {
-	if len(tagIDs) == 0 {
-		return map[uuid.UUID]int{}, nil
-	}
-
-	args := make([]any, len(tagIDs))
-	var placeholders strings.Builder
-	for i, id := range tagIDs {
-		if i > 0 {
-			placeholders.WriteString(", ")
-		}
-		placeholders.WriteString("$" + strconv.Itoa(i+1))
-		args[i] = id
-	}
-
-	rows, err := s.db.QueryContext(ctx,
-		"SELECT tag_id, COUNT(*) FROM posts_tags WHERE tag_id IN ("+placeholders.String()+") GROUP BY tag_id",
-		args...,
-	)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = rows.Close() }()
-
-	counts := make(map[uuid.UUID]int)
-	for rows.Next() {
-		var tagID uuid.UUID
-		var count int
-		if err := rows.Scan(&tagID, &count); err != nil {
-			return nil, err
-		}
-		counts[tagID] = count
-	}
-	return counts, rows.Err()
 }
 
 func (s *Server) ConvertTagToAlias(w http.ResponseWriter, r *http.Request, name Tag) {
@@ -472,160 +252,21 @@ func (s *Server) ConvertTagToAlias(w http.ResponseWriter, r *http.Request, name 
 		return
 	}
 
-	tx, err := s.db.DB.BeginTx(ctx, nil)
+	result, err := s.sqlStore.ConvertTagToAlias(ctx, name, body.Target)
 	if err != nil {
-		respondWithError(w, http.StatusInternalServerError, "Failed to begin transaction")
-		return
-	}
-	defer func() { _ = tx.Rollback() }()
-
-	// Look up source tag
-	var sourceID uuid.UUID
-	err = tx.QueryRowContext(ctx, "SELECT id FROM tags WHERE name = $1", name).Scan(&sourceID)
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			respondWithError(w, http.StatusNotFound, "Source tag %q not found", name)
+		if errors.Is(err, store.ErrNotFound) {
+			respondWithError(w, http.StatusNotFound, "%v", err)
 			return
 		}
-		respondWithError(w, http.StatusInternalServerError, "Failed to look up source tag")
-		return
-	}
-
-	// Look up target tag
-	var targetID uuid.UUID
-	err = tx.QueryRowContext(ctx, "SELECT id FROM tags WHERE name = $1", body.Target).Scan(&targetID)
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			respondWithError(w, http.StatusNotFound, "Target tag %q not found", body.Target)
-			return
-		}
-		respondWithError(w, http.StatusInternalServerError, "Failed to look up target tag")
-		return
-	}
-
-	// Re-tag posts: move source associations to target where target doesn't already exist
-	_, err = tx.ExecContext(ctx,
-		`UPDATE posts_tags SET tag_id = $1
-		 WHERE tag_id = $2
-		   AND NOT EXISTS (SELECT 1 FROM posts_tags pt2 WHERE pt2.post_id = posts_tags.post_id AND pt2.tag_id = $1)`,
-		targetID, sourceID,
-	)
-	if err != nil {
-		respondWithError(w, http.StatusInternalServerError, "Failed to re-tag posts")
-		return
-	}
-
-	// Delete remaining source associations (posts that already had the target tag)
-	_, err = tx.ExecContext(ctx, "DELETE FROM posts_tags WHERE tag_id = $1", sourceID)
-	if err != nil {
-		respondWithError(w, http.StatusInternalServerError, "Failed to clean up source tag associations")
-		return
-	}
-
-	// Collect source aliases before deleting
-	aliasRows, err := tx.QueryContext(ctx, "SELECT alias_name FROM tag_aliases WHERE tag_id = $1", sourceID)
-	if err != nil {
-		respondWithError(w, http.StatusInternalServerError, "Failed to collect source aliases")
-		return
-	}
-	defer func() { _ = aliasRows.Close() }()
-	var sourceAliases []string
-	for aliasRows.Next() {
-		var alias string
-		if err := aliasRows.Scan(&alias); err != nil {
-			respondWithError(w, http.StatusInternalServerError, "Failed to read source aliases")
-			return
-		}
-		sourceAliases = append(sourceAliases, alias)
-	}
-	if err := aliasRows.Err(); err != nil {
-		respondWithError(w, http.StatusInternalServerError, "Failed to iterate source aliases")
-		return
-	}
-
-	// Delete source tag (cascades aliases)
-	_, err = tx.ExecContext(ctx, "DELETE FROM tags WHERE id = $1", sourceID)
-	if err != nil {
-		respondWithError(w, http.StatusInternalServerError, "Failed to delete source tag")
-		return
-	}
-
-	// Add source name + source aliases as aliases of target
-	allNewAliases := append([]string{name}, sourceAliases...)
-	for _, alias := range allNewAliases {
-		_, err = tx.ExecContext(ctx,
-			"INSERT INTO tag_aliases (tag_id, alias_name) VALUES ($1, $2) ON CONFLICT DO NOTHING",
-			targetID, alias,
-		)
-		if err != nil {
-			respondWithError(w, http.StatusInternalServerError, "Failed to add alias %q", alias)
-			return
-		}
-	}
-
-	// Read the target tag and its aliases within the transaction so the
-	// response is consistent even if a concurrent request modifies it.
-	var tagName, tagDesc string
-	var tagCatID sql.Null[uuid.UUID]
-	var tagCreatedAt, tagUpdatedAt time.Time
-	err = tx.QueryRowContext(ctx,
-		"SELECT name, description, tag_category_id, created_at, updated_at FROM tags WHERE id = $1",
-		targetID,
-	).Scan(&tagName, &tagDesc, &tagCatID, &tagCreatedAt, &tagUpdatedAt)
-	if err != nil {
-		respondWithError(w, http.StatusInternalServerError, "Failed to retrieve updated target tag")
-		return
-	}
-
-	var catName *string
-	if tagCatID.Valid {
-		var cn string
-		err = tx.QueryRowContext(ctx, "SELECT name FROM tag_categories WHERE id = $1", tagCatID.V).Scan(&cn)
-		if err != nil && !errors.Is(err, sql.ErrNoRows) {
-			respondWithError(w, http.StatusInternalServerError, "Failed to load tag category")
-			return
-		}
-		if err == nil {
-			catName = &cn
-		}
-	}
-
-	txAliasRows, err := tx.QueryContext(ctx, "SELECT alias_name FROM tag_aliases WHERE tag_id = $1 ORDER BY alias_name", targetID)
-	if err != nil {
-		respondWithError(w, http.StatusInternalServerError, "Failed to load tag aliases")
-		return
-	}
-	defer func() { _ = txAliasRows.Close() }()
-	var targetAliases []string
-	for txAliasRows.Next() {
-		var a string
-		if err := txAliasRows.Scan(&a); err != nil {
-			respondWithError(w, http.StatusInternalServerError, "Failed to read tag aliases")
-			return
-		}
-		targetAliases = append(targetAliases, a)
-	}
-	if err := txAliasRows.Err(); err != nil {
-		respondWithError(w, http.StatusInternalServerError, "Failed to iterate tag aliases")
-		return
-	}
-
-	if err := tx.Commit(); err != nil {
-		respondWithError(w, http.StatusInternalServerError, "Failed to commit transaction")
+		respondWithError(w, http.StatusInternalServerError, "Failed to convert tag to alias")
 		return
 	}
 
 	zerolog.Ctx(ctx).Info().Str("source", name).Str("target", body.Target).Msg("tag converted to alias")
 
-	tagResp := types.Tag{
-		Name:        tagName,
-		Description: tagDesc,
-		Category:    catName,
-		CreatedAt:   tagCreatedAt,
-		UpdatedAt:   tagUpdatedAt,
-	}
-	if len(targetAliases) > 0 {
-		tagResp.Aliases = &targetAliases
+	tagResp := tagFromModel(result.Tag)
+	if len(result.Aliases) > 0 {
+		tagResp.Aliases = &result.Aliases
 	}
 
 	respond(w, http.StatusOK, tagResp)
@@ -639,11 +280,9 @@ func (s *Server) DeleteTag(w http.ResponseWriter, r *http.Request, name Tag) {
 		return
 	}
 
-	_, err := models.Tags.Delete(
-		dm.Where(models.Tags.Columns.Name.EQ(psql.Arg(name))),
-	).Exec(ctx, s.db)
+	err := s.sqlStore.DeleteTag(ctx, name)
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
+		if errors.Is(err, store.ErrNotFound) {
 			respondWithError(w, http.StatusNotFound, "Tag %q not found", name)
 			return
 		}

--- a/internal/api/testdb_test.go
+++ b/internal/api/testdb_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/dharmab/hyperboard/internal/db/migrations"
+	"github.com/dharmab/hyperboard/internal/db/store"
 	"github.com/dharmab/hyperboard/internal/storage/memory"
 	embedpg "github.com/fergusstrange/embedded-postgres"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -68,5 +69,6 @@ func newTestServer(t *testing.T) *Server {
 	t.Helper()
 	// No cleanup needed: tests use unique random data (UUIDs, random tag names)
 	// and query by specific IDs/names, so they don't interfere with each other.
-	return NewServer(testDB, memory.New(), 5)
+	s := store.NewPostgresSQLStore(testDB, 5)
+	return NewServer(s, memory.New())
 }

--- a/internal/db/store/notes.go
+++ b/internal/db/store/notes.go
@@ -1,0 +1,83 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"time"
+
+	"github.com/dharmab/hyperboard/internal/db/models"
+	"github.com/gofrs/uuid/v5"
+	"github.com/stephenafamo/bob/dialect/psql"
+	"github.com/stephenafamo/bob/dialect/psql/dm"
+	"github.com/stephenafamo/bob/dialect/psql/sm"
+)
+
+func (s *PostgresSQLStore) ListNotes(ctx context.Context) (models.NoteSlice, error) {
+	return models.Notes.Query(
+		sm.OrderBy(models.Notes.Columns.CreatedAt).Desc(),
+	).All(ctx, s.db)
+}
+
+func (s *PostgresSQLStore) GetNote(ctx context.Context, id uuid.UUID) (*models.Note, error) {
+	model, err := models.Notes.Query(
+		sm.Where(models.Notes.Columns.ID.EQ(psql.Arg(id))),
+	).One(ctx, s.db)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return model, nil
+}
+
+func (s *PostgresSQLStore) CreateNote(ctx context.Context, title, content string) (*models.Note, error) {
+	id, err := uuid.NewV4()
+	if err != nil {
+		return nil, err
+	}
+	now := new(time.Now().UTC())
+	return models.Notes.Insert(
+		&models.NoteSetter{
+			ID:        &id,
+			Title:     &title,
+			Content:   &content,
+			CreatedAt: now,
+			UpdatedAt: now,
+		},
+	).One(ctx, s.db)
+}
+
+func (s *PostgresSQLStore) UpdateNote(ctx context.Context, id uuid.UUID, title, content string) (*models.Note, error) {
+	model, err := s.GetNote(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	now := new(time.Now().UTC())
+	err = model.Update(ctx, s.db, &models.NoteSetter{
+		Title:     &title,
+		Content:   &content,
+		UpdatedAt: now,
+	})
+	if err != nil {
+		return nil, err
+	}
+	model.Title = title
+	model.Content = content
+	model.UpdatedAt = *now
+	return model, nil
+}
+
+func (s *PostgresSQLStore) DeleteNote(ctx context.Context, id uuid.UUID) error {
+	_, err := s.GetNote(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	_, err = models.Notes.Delete(
+		dm.Where(models.Notes.Columns.ID.EQ(psql.Arg(id))),
+	).Exec(ctx, s.db)
+	return err
+}

--- a/internal/db/store/postgres.go
+++ b/internal/db/store/postgres.go
@@ -1,0 +1,27 @@
+package store
+
+import (
+	"context"
+
+	"github.com/stephenafamo/bob"
+)
+
+// PostgresSQLStore implements the Store interface using a PostgreSQL database via Bob ORM.
+type PostgresSQLStore struct {
+	db                  bob.DB
+	similarityThreshold int
+}
+
+var _ SQLStore = &PostgresSQLStore{}
+
+// NewPostgresSQLStore creates a new PostgresStore backed by the given bob.DB.
+func NewPostgresSQLStore(db bob.DB, similarityThreshold int) *PostgresSQLStore {
+	return &PostgresSQLStore{
+		db:                  db,
+		similarityThreshold: similarityThreshold,
+	}
+}
+
+func (s *PostgresSQLStore) Ping(ctx context.Context) error {
+	return s.db.PingContext(ctx)
+}

--- a/internal/db/store/posts.go
+++ b/internal/db/store/posts.go
@@ -1,0 +1,384 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strconv"
+	"time"
+
+	"github.com/dharmab/hyperboard/internal/db/models"
+	"github.com/dharmab/hyperboard/internal/search"
+	"github.com/gofrs/uuid/v5"
+	"github.com/stephenafamo/bob"
+	"github.com/stephenafamo/bob/dialect/psql"
+	"github.com/stephenafamo/bob/dialect/psql/dialect"
+	"github.com/stephenafamo/bob/dialect/psql/dm"
+	"github.com/stephenafamo/bob/dialect/psql/sm"
+)
+
+func (s *PostgresSQLStore) ListPosts(ctx context.Context, params ListPostsParams) (models.PostSlice, bool, error) {
+	mods := []bob.Mod[*dialect.SelectQuery]{}
+
+	// Apply tag inclusion filters
+	for _, tagName := range params.Query.IncludedTags {
+		resolved, err := s.ResolveAlias(ctx, tagName)
+		if err != nil {
+			return nil, false, err
+		}
+		mods = append(mods, sm.Where(psql.F("EXISTS",
+			psql.Select(
+				sm.Columns(psql.S("1")),
+				sm.From("posts_tags"),
+				sm.InnerJoin("tags").OnEQ(models.PostsTags.Columns.TagID, models.Tags.Columns.ID),
+				sm.Where(psql.And(
+					models.PostsTags.Columns.PostID.EQ(models.Posts.Columns.ID),
+					models.Tags.Columns.Name.EQ(psql.Arg(resolved)),
+				)),
+			),
+		)))
+	}
+
+	// Apply tag exclusion filters
+	for _, tagName := range params.Query.ExcludedTags {
+		resolved, err := s.ResolveAlias(ctx, tagName)
+		if err != nil {
+			return nil, false, err
+		}
+		mods = append(mods, sm.Where(psql.Not(psql.F("EXISTS",
+			psql.Select(
+				sm.Columns(psql.S("1")),
+				sm.From("posts_tags"),
+				sm.InnerJoin("tags").OnEQ(models.PostsTags.Columns.TagID, models.Tags.Columns.ID),
+				sm.Where(psql.And(
+					models.PostsTags.Columns.PostID.EQ(models.Posts.Columns.ID),
+					models.Tags.Columns.Name.EQ(psql.Arg(resolved)),
+				)),
+			),
+		))))
+	}
+
+	// Apply tagged: filter
+	if params.Query.Tagged != nil {
+		if *params.Query.Tagged {
+			mods = append(mods, sm.Where(psql.F("EXISTS",
+				psql.Select(
+					sm.Columns(psql.S("1")),
+					sm.From("posts_tags"),
+					sm.InnerJoin("tags").OnEQ(models.PostsTags.Columns.TagID, models.Tags.Columns.ID),
+					sm.Where(models.PostsTags.Columns.PostID.EQ(models.Posts.Columns.ID)),
+				),
+			)))
+		} else {
+			mods = append(mods, sm.Where(psql.Not(psql.F("EXISTS",
+				psql.Select(
+					sm.Columns(psql.S("1")),
+					sm.From("posts_tags"),
+					sm.InnerJoin("tags").OnEQ(models.PostsTags.Columns.TagID, models.Tags.Columns.ID),
+					sm.Where(models.PostsTags.Columns.PostID.EQ(models.Posts.Columns.ID)),
+				),
+			))))
+		}
+	}
+
+	// Apply type filters
+	if params.Query.TypeImage {
+		mods = append(mods, sm.Where(models.Posts.Columns.MimeType.Like(psql.Arg("image/%"))))
+	}
+	if params.Query.TypeVideo {
+		mods = append(mods, sm.Where(models.Posts.Columns.MimeType.Like(psql.Arg("video/%"))))
+	}
+	if params.Query.TypeAudio {
+		mods = append(mods, sm.Where(models.Posts.Columns.HasAudio.EQ(psql.Arg(true))))
+	}
+
+	// Random sort
+	if params.Query.Sort == search.SortRandom {
+		seed := params.RandomSeed
+		if seed == nil {
+			currentSeed := time.Now().Unix() / 21600
+			seed = &currentSeed
+		}
+
+		mods = append(mods,
+			sm.OrderBy(dialect.NewFunction("md5",
+				psql.Cast(models.Posts.Columns.ID, "text").Concat(psql.Arg(strconv.FormatInt(*seed, 10))),
+			)),
+			sm.Limit(int64(params.Limit+1)),
+			sm.Offset(int64(params.RandomOffset)),
+		)
+
+		posts, err := models.Posts.Query(mods...).All(ctx, s.db)
+		if err != nil {
+			return nil, false, err
+		}
+
+		if err := posts.LoadTags(ctx, s.db); err != nil {
+			return nil, false, err
+		}
+
+		hasMore := len(posts) > params.Limit
+		if hasMore {
+			posts = posts[:params.Limit]
+		}
+		return posts, hasMore, nil
+	}
+
+	// Deterministic sort (created_at or updated_at)
+	sortCol := models.Posts.Columns.CreatedAt
+	if params.Query.Sort == search.SortUpdatedAt {
+		sortCol = models.Posts.Columns.UpdatedAt
+	}
+	mods = append(mods,
+		sm.OrderBy(sortCol).Desc(),
+		sm.OrderBy(models.Posts.Columns.ID).Desc(),
+	)
+
+	if params.CursorTime != nil && params.CursorID != nil {
+		mods = append(mods, sm.Where(psql.Or(
+			sortCol.LT(psql.Arg(*params.CursorTime)),
+			psql.And(
+				sortCol.EQ(psql.Arg(*params.CursorTime)),
+				models.Posts.Columns.ID.LT(psql.Arg(*params.CursorID)),
+			),
+		)))
+	}
+
+	mods = append(mods, sm.Limit(int64(params.Limit+1)))
+
+	posts, err := models.Posts.Query(mods...).All(ctx, s.db)
+	if err != nil {
+		return nil, false, err
+	}
+
+	if err := posts.LoadTags(ctx, s.db); err != nil {
+		return nil, false, err
+	}
+
+	hasMore := len(posts) > params.Limit
+	if hasMore {
+		posts = posts[:params.Limit]
+	}
+	return posts, hasMore, nil
+}
+
+func (s *PostgresSQLStore) GetPost(ctx context.Context, id uuid.UUID) (*models.Post, error) {
+	model, err := models.Posts.Query(
+		sm.Where(models.Posts.Columns.ID.EQ(psql.Arg(id))),
+	).One(ctx, s.db)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+
+	if err := model.LoadTags(ctx, s.db); err != nil {
+		return nil, err
+	}
+
+	return model, nil
+}
+
+func (s *PostgresSQLStore) CreatePost(ctx context.Context, setter *models.PostSetter) (*models.Post, error) {
+	return models.Posts.Insert(setter).One(ctx, s.db)
+}
+
+func (s *PostgresSQLStore) UpdatePost(ctx context.Context, id uuid.UUID, note string, tagNames []string, now time.Time) (*models.Post, error) {
+	existingPost, err := models.Posts.Query(
+		sm.Where(models.Posts.Columns.ID.EQ(psql.Arg(id))),
+	).One(ctx, s.db)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	nowPtr := &now
+	err = existingPost.Update(ctx, tx, &models.PostSetter{
+		Note:      &note,
+		UpdatedAt: nowPtr,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = models.PostsTags.Delete(
+		dm.Where(models.PostsTags.Columns.PostID.EQ(psql.Arg(id))),
+	).Exec(ctx, tx)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, tagName := range tagNames {
+		resolvedName, resolveErr := s.resolveAliasWithExec(ctx, tx, tagName)
+		if resolveErr != nil {
+			return nil, resolveErr
+		}
+		_, err = tx.ExecContext(ctx,
+			"INSERT INTO tags (name, created_at, updated_at) VALUES ($1, $2, $3) ON CONFLICT (name) DO NOTHING",
+			resolvedName, nowPtr, nowPtr,
+		)
+		if err != nil {
+			return nil, err
+		}
+		tag, err := models.Tags.Query(
+			sm.Where(models.Tags.Columns.Name.EQ(psql.Arg(resolvedName))),
+		).One(ctx, tx)
+		if err != nil {
+			return nil, err
+		}
+		err = existingPost.AttachTags(ctx, tx, tag)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if err := existingPost.LoadTags(ctx, tx); err != nil {
+		return nil, err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, err
+	}
+
+	return existingPost, nil
+}
+
+func (s *PostgresSQLStore) UpdatePostContent(ctx context.Context, id uuid.UUID, setter *models.PostSetter) (*models.Post, error) {
+	existingPost, err := models.Posts.Query(
+		sm.Where(models.Posts.Columns.ID.EQ(psql.Arg(id))),
+	).One(ctx, s.db)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+
+	err = existingPost.Update(ctx, s.db, setter)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = existingPost.LoadTags(ctx, s.db); err != nil {
+		return nil, err
+	}
+
+	return existingPost, nil
+}
+
+func (s *PostgresSQLStore) UpdatePostThumbnail(ctx context.Context, id uuid.UUID, thumbnailURL string, now time.Time) (*models.Post, error) {
+	existingPost, err := models.Posts.Query(
+		sm.Where(models.Posts.Columns.ID.EQ(psql.Arg(id))),
+	).One(ctx, s.db)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+
+	nowPtr := &now
+	err = existingPost.Update(ctx, s.db, &models.PostSetter{
+		ThumbnailURL: &thumbnailURL,
+		UpdatedAt:    nowPtr,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if err := existingPost.LoadTags(ctx, s.db); err != nil {
+		return nil, err
+	}
+
+	return existingPost, nil
+}
+
+func (s *PostgresSQLStore) DeletePost(ctx context.Context, id uuid.UUID) (*models.Post, error) {
+	post, err := models.Posts.Query(
+		sm.Where(models.Posts.Columns.ID.EQ(psql.Arg(id))),
+	).One(ctx, s.db)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+
+	_, err = models.Posts.Delete(
+		dm.Where(models.Posts.Columns.ID.EQ(psql.Arg(id))),
+	).Exec(ctx, s.db)
+	if err != nil {
+		return nil, err
+	}
+
+	return post, nil
+}
+
+func (s *PostgresSQLStore) FindPostBySha256(ctx context.Context, hash string) (*models.Post, error) {
+	model, err := models.Posts.Query(
+		sm.Where(models.Posts.Columns.Sha256.EQ(psql.Arg(hash))),
+	).One(ctx, s.db)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return model, nil
+}
+
+func (s *PostgresSQLStore) FindSimilarPosts(ctx context.Context, excludeID uuid.UUID, pHash int64, limit int) (models.PostSlice, error) {
+	phashHamming := dialect.NewFunction("bit_count",
+		psql.Cast(psql.Group(models.Posts.Columns.Phash.OP("#", psql.Arg(pHash))), "bit(64)"),
+	)
+	mods := []bob.Mod[*dialect.SelectQuery]{
+		sm.Where(models.Posts.Columns.Phash.IsNotNull()),
+		sm.Where(phashHamming.LTE(psql.Arg(s.similarityThreshold))),
+		sm.OrderBy(phashHamming),
+		sm.Limit(int64(limit)),
+	}
+
+	if excludeID != uuid.Nil {
+		mods = append(mods, sm.Where(models.Posts.Columns.ID.NE(psql.Arg(excludeID))))
+	}
+
+	posts, err := models.Posts.Query(mods...).All(ctx, s.db)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := posts.LoadTags(ctx, s.db); err != nil {
+		return nil, err
+	}
+
+	return posts, nil
+}
+
+// resolveAliasWithExec resolves an alias using a specific executor (for use within transactions).
+func (s *PostgresSQLStore) resolveAliasWithExec(ctx context.Context, exec bob.Executor, name string) (string, error) {
+	rows, err := exec.QueryContext(ctx,
+		"SELECT t.name FROM tags t JOIN tag_aliases ta ON t.id = ta.tag_id WHERE ta.alias_name = $1",
+		name,
+	)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = rows.Close() }()
+	if rows.Next() {
+		var canonical string
+		if err := rows.Scan(&canonical); err != nil {
+			return "", err
+		}
+		return canonical, rows.Err()
+	}
+	return name, rows.Err()
+}

--- a/internal/db/store/store.go
+++ b/internal/db/store/store.go
@@ -1,0 +1,106 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"time"
+
+	"github.com/dharmab/hyperboard/internal/db/models"
+	"github.com/dharmab/hyperboard/internal/search"
+	"github.com/gofrs/uuid/v5"
+)
+
+var (
+	ErrNotFound      = errors.New("not found")
+	ErrAliasConflict = errors.New("alias conflicts with existing tag name")
+)
+
+// SQLStore combines all sub-interfaces for database operations.
+type SQLStore interface {
+	Pinger
+	NoteStore
+	TagCategoryStore
+	TagStore
+	PostStore
+}
+
+// Pinger provides database connectivity checks.
+type Pinger interface {
+	Ping(ctx context.Context) error
+}
+
+// NoteStore provides CRUD operations for notes.
+type NoteStore interface {
+	ListNotes(ctx context.Context) (models.NoteSlice, error)
+	GetNote(ctx context.Context, id uuid.UUID) (*models.Note, error)
+	CreateNote(ctx context.Context, title, content string) (*models.Note, error)
+	UpdateNote(ctx context.Context, id uuid.UUID, title, content string) (*models.Note, error)
+	DeleteNote(ctx context.Context, id uuid.UUID) error
+}
+
+// TagCategoryStore provides CRUD operations for tag categories.
+type TagCategoryStore interface {
+	ListTagCategories(ctx context.Context, cursor *string, limit int) (models.TagCategorySlice, bool, error)
+	GetTagCategory(ctx context.Context, name string) (*models.TagCategory, error)
+	UpsertTagCategory(ctx context.Context, urlName string, input TagCategoryInput, now time.Time) (*models.TagCategory, bool, error)
+	DeleteTagCategory(ctx context.Context, name string) error
+	GetTagCountsByCategory(ctx context.Context, ids []uuid.UUID) (map[uuid.UUID]int, error)
+}
+
+// TagCategoryInput holds the fields for creating or updating a tag category.
+type TagCategoryInput struct {
+	Name        string
+	Description string
+	Color       string
+}
+
+// TagStore provides CRUD operations for tags.
+type TagStore interface {
+	ListTags(ctx context.Context, cursor *string, limit int) (models.TagSlice, bool, error)
+	GetTag(ctx context.Context, name string) (*models.Tag, error)
+	UpsertTag(ctx context.Context, urlName string, input TagInput, now time.Time) (*models.Tag, bool, error)
+	DeleteTag(ctx context.Context, name string) error
+	GetTagPostCounts(ctx context.Context, ids []uuid.UUID) (map[uuid.UUID]int, error)
+	GetTagAliases(ctx context.Context, ids ...uuid.UUID) (map[uuid.UUID][]string, error)
+	ResolveAlias(ctx context.Context, name string) (string, error)
+	ConvertTagToAlias(ctx context.Context, sourceName, targetName string) (*ConvertTagToAliasResult, error)
+}
+
+// TagInput holds the fields for creating or updating a tag.
+type TagInput struct {
+	Name          string
+	Description   string
+	Category      *string
+	Aliases       []string
+	TagCategoryID sql.Null[uuid.UUID]
+}
+
+// ConvertTagToAliasResult holds the result of converting a tag to an alias.
+type ConvertTagToAliasResult struct {
+	Tag     *models.Tag
+	Aliases []string
+}
+
+// PostStore provides CRUD operations for posts.
+type PostStore interface {
+	ListPosts(ctx context.Context, params ListPostsParams) (models.PostSlice, bool, error)
+	GetPost(ctx context.Context, id uuid.UUID) (*models.Post, error)
+	CreatePost(ctx context.Context, setter *models.PostSetter) (*models.Post, error)
+	UpdatePost(ctx context.Context, id uuid.UUID, note string, tagNames []string, now time.Time) (*models.Post, error)
+	UpdatePostContent(ctx context.Context, id uuid.UUID, setter *models.PostSetter) (*models.Post, error)
+	UpdatePostThumbnail(ctx context.Context, id uuid.UUID, thumbnailURL string, now time.Time) (*models.Post, error)
+	DeletePost(ctx context.Context, id uuid.UUID) (*models.Post, error)
+	FindPostBySha256(ctx context.Context, hash string) (*models.Post, error)
+	FindSimilarPosts(ctx context.Context, excludeID uuid.UUID, pHash int64, limit int) (models.PostSlice, error)
+}
+
+// ListPostsParams holds parameters for listing posts.
+type ListPostsParams struct {
+	Query        search.Query
+	Limit        int
+	CursorTime   *time.Time
+	CursorID     *uuid.UUID
+	RandomSeed   *int64
+	RandomOffset int
+}

--- a/internal/db/store/tag_categories.go
+++ b/internal/db/store/tag_categories.go
@@ -1,0 +1,144 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/dharmab/hyperboard/internal/db/models"
+	"github.com/gofrs/uuid/v5"
+	"github.com/stephenafamo/bob"
+	"github.com/stephenafamo/bob/dialect/psql"
+	"github.com/stephenafamo/bob/dialect/psql/dialect"
+	"github.com/stephenafamo/bob/dialect/psql/dm"
+	"github.com/stephenafamo/bob/dialect/psql/sm"
+)
+
+func (s *PostgresSQLStore) ListTagCategories(ctx context.Context, cursor *string, limit int) (models.TagCategorySlice, bool, error) {
+	mods := []bob.Mod[*dialect.SelectQuery]{
+		sm.OrderBy(models.TagCategories.Columns.Name).Asc(),
+	}
+
+	if cursor != nil {
+		mods = append(mods, sm.Where(models.TagCategories.Columns.Name.GT(psql.Arg(*cursor))))
+	}
+
+	mods = append(mods, sm.Limit(int64(limit+1)))
+
+	categories, err := models.TagCategories.Query(mods...).All(ctx, s.db)
+	if err != nil {
+		return nil, false, err
+	}
+
+	hasMore := len(categories) > limit
+	if hasMore {
+		categories = categories[:limit]
+	}
+	return categories, hasMore, nil
+}
+
+func (s *PostgresSQLStore) GetTagCategory(ctx context.Context, name string) (*models.TagCategory, error) {
+	model, err := models.TagCategories.Query(
+		sm.Where(models.TagCategories.Columns.Name.EQ(psql.Arg(name))),
+	).One(ctx, s.db)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return model, nil
+}
+
+func (s *PostgresSQLStore) UpsertTagCategory(ctx context.Context, urlName string, input TagCategoryInput, now time.Time) (*models.TagCategory, bool, error) {
+	existing, err := models.TagCategories.Query(
+		sm.Where(models.TagCategories.Columns.Name.EQ(psql.Arg(urlName))),
+	).One(ctx, s.db)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return nil, false, err
+	}
+
+	nowPtr := &now
+	if existing != nil {
+		err = existing.Update(ctx, s.db, &models.TagCategorySetter{
+			Name:        &input.Name,
+			Description: &input.Description,
+			Color:       &input.Color,
+			UpdatedAt:   nowPtr,
+		})
+		if err != nil {
+			return nil, false, err
+		}
+		existing.Name = input.Name
+		existing.Description = input.Description
+		existing.Color = input.Color
+		existing.UpdatedAt = now
+		return existing, false, nil
+	}
+
+	inserted, err := models.TagCategories.Insert(
+		&models.TagCategorySetter{
+			Name:        &input.Name,
+			Description: &input.Description,
+			Color:       &input.Color,
+			CreatedAt:   nowPtr,
+			UpdatedAt:   nowPtr,
+		},
+	).One(ctx, s.db)
+	if err != nil {
+		return nil, false, err
+	}
+	return inserted, true, nil
+}
+
+func (s *PostgresSQLStore) DeleteTagCategory(ctx context.Context, name string) error {
+	_, err := models.TagCategories.Delete(
+		dm.Where(models.TagCategories.Columns.Name.EQ(psql.Arg(name))),
+	).Exec(ctx, s.db)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrNotFound
+		}
+		return err
+	}
+	return nil
+}
+
+func (s *PostgresSQLStore) GetTagCountsByCategory(ctx context.Context, categoryIDs []uuid.UUID) (map[uuid.UUID]int, error) {
+	if len(categoryIDs) == 0 {
+		return map[uuid.UUID]int{}, nil
+	}
+
+	args := make([]any, len(categoryIDs))
+	var placeholders strings.Builder
+	for i, id := range categoryIDs {
+		if i > 0 {
+			placeholders.WriteString(", ")
+		}
+		placeholders.WriteString("$" + strconv.Itoa(i+1))
+		args[i] = id
+	}
+
+	rows, err := s.db.QueryContext(ctx,
+		"SELECT tag_category_id, COUNT(*) FROM tags WHERE tag_category_id IN ("+placeholders.String()+") GROUP BY tag_category_id",
+		args...,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	counts := make(map[uuid.UUID]int)
+	for rows.Next() {
+		var catID uuid.UUID
+		var count int
+		if err := rows.Scan(&catID, &count); err != nil {
+			return nil, err
+		}
+		counts[catID] = count
+	}
+	return counts, rows.Err()
+}

--- a/internal/db/store/tags.go
+++ b/internal/db/store/tags.go
@@ -1,0 +1,420 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/dharmab/hyperboard/internal/db/models"
+	"github.com/gofrs/uuid/v5"
+	"github.com/stephenafamo/bob"
+	"github.com/stephenafamo/bob/dialect/psql"
+	"github.com/stephenafamo/bob/dialect/psql/dialect"
+	"github.com/stephenafamo/bob/dialect/psql/dm"
+	"github.com/stephenafamo/bob/dialect/psql/sm"
+)
+
+func (s *PostgresSQLStore) ListTags(ctx context.Context, cursor *string, limit int) (models.TagSlice, bool, error) {
+	mods := []bob.Mod[*dialect.SelectQuery]{
+		sm.OrderBy(models.Tags.Columns.Name).Asc(),
+	}
+
+	if cursor != nil {
+		mods = append(mods, sm.Where(models.Tags.Columns.Name.GT(psql.Arg(*cursor))))
+	}
+
+	mods = append(mods, sm.Limit(int64(limit+1)))
+
+	tags, err := models.Tags.Query(mods...).All(ctx, s.db)
+	if err != nil {
+		return nil, false, err
+	}
+
+	if err := tags.LoadTagCategory(ctx, s.db); err != nil {
+		return nil, false, err
+	}
+
+	hasMore := len(tags) > limit
+	if hasMore {
+		tags = tags[:limit]
+	}
+	return tags, hasMore, nil
+}
+
+func (s *PostgresSQLStore) GetTag(ctx context.Context, name string) (*models.Tag, error) {
+	model, err := models.Tags.Query(
+		sm.Where(models.Tags.Columns.Name.EQ(psql.Arg(name))),
+	).One(ctx, s.db)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+
+	if model.TagCategoryID.Valid {
+		if err := model.LoadTagCategory(ctx, s.db); err != nil {
+			return nil, err
+		}
+	}
+
+	return model, nil
+}
+
+func (s *PostgresSQLStore) UpsertTag(ctx context.Context, urlName string, input TagInput, now time.Time) (*models.Tag, bool, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, false, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	existing, err := models.Tags.Query(
+		sm.Where(models.Tags.Columns.Name.EQ(psql.Arg(urlName))),
+	).One(ctx, tx)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return nil, false, err
+	}
+
+	nowPtr := &now
+	var resultModel *models.Tag
+	isCreate := existing == nil
+
+	if existing != nil {
+		err = existing.Update(ctx, tx, &models.TagSetter{
+			Name:          &input.Name,
+			Description:   &input.Description,
+			TagCategoryID: &input.TagCategoryID,
+			UpdatedAt:     nowPtr,
+		})
+		if err != nil {
+			return nil, false, err
+		}
+		existing.Name = input.Name
+		existing.Description = input.Description
+		existing.TagCategoryID = input.TagCategoryID
+		resultModel = existing
+	} else {
+		resultModel, err = models.Tags.Insert(
+			&models.TagSetter{
+				Name:          &input.Name,
+				Description:   &input.Description,
+				TagCategoryID: &input.TagCategoryID,
+				CreatedAt:     nowPtr,
+				UpdatedAt:     nowPtr,
+			},
+		).One(ctx, tx)
+		if err != nil {
+			return nil, false, err
+		}
+	}
+
+	if err := s.setTagAliases(ctx, tx, resultModel.ID, input.Aliases); err != nil {
+		return nil, false, err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, false, err
+	}
+
+	if resultModel.TagCategoryID.Valid {
+		if err := resultModel.LoadTagCategory(ctx, s.db); err != nil {
+			return nil, false, err
+		}
+	}
+
+	return resultModel, isCreate, nil
+}
+
+func (s *PostgresSQLStore) DeleteTag(ctx context.Context, name string) error {
+	_, err := models.Tags.Delete(
+		dm.Where(models.Tags.Columns.Name.EQ(psql.Arg(name))),
+	).Exec(ctx, s.db)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrNotFound
+		}
+		return err
+	}
+	return nil
+}
+
+func (s *PostgresSQLStore) GetTagPostCounts(ctx context.Context, tagIDs []uuid.UUID) (map[uuid.UUID]int, error) {
+	if len(tagIDs) == 0 {
+		return map[uuid.UUID]int{}, nil
+	}
+
+	args := make([]any, len(tagIDs))
+	var placeholders strings.Builder
+	for i, id := range tagIDs {
+		if i > 0 {
+			placeholders.WriteString(", ")
+		}
+		placeholders.WriteString("$" + strconv.Itoa(i+1))
+		args[i] = id
+	}
+
+	rows, err := s.db.QueryContext(ctx,
+		"SELECT tag_id, COUNT(*) FROM posts_tags WHERE tag_id IN ("+placeholders.String()+") GROUP BY tag_id",
+		args...,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	counts := make(map[uuid.UUID]int)
+	for rows.Next() {
+		var tagID uuid.UUID
+		var count int
+		if err := rows.Scan(&tagID, &count); err != nil {
+			return nil, err
+		}
+		counts[tagID] = count
+	}
+	return counts, rows.Err()
+}
+
+func (s *PostgresSQLStore) GetTagAliases(ctx context.Context, ids ...uuid.UUID) (map[uuid.UUID][]string, error) {
+	if len(ids) == 0 {
+		return map[uuid.UUID][]string{}, nil
+	}
+
+	args := make([]any, len(ids))
+	var placeholders strings.Builder
+	for i, id := range ids {
+		if i > 0 {
+			placeholders.WriteString(", ")
+		}
+		placeholders.WriteString("$" + strconv.Itoa(i+1))
+		args[i] = id
+	}
+
+	rows, err := s.db.QueryContext(ctx,
+		"SELECT tag_id, alias_name FROM tag_aliases WHERE tag_id IN ("+placeholders.String()+") ORDER BY alias_name",
+		args...,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	result := make(map[uuid.UUID][]string)
+	for rows.Next() {
+		var tagID uuid.UUID
+		var alias string
+		if err := rows.Scan(&tagID, &alias); err != nil {
+			return nil, err
+		}
+		result[tagID] = append(result[tagID], alias)
+	}
+	return result, rows.Err()
+}
+
+func (s *PostgresSQLStore) ResolveAlias(ctx context.Context, name string) (string, error) {
+	rows, err := s.db.QueryContext(ctx,
+		"SELECT t.name FROM tags t JOIN tag_aliases ta ON t.id = ta.tag_id WHERE ta.alias_name = $1",
+		name,
+	)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = rows.Close() }()
+	if rows.Next() {
+		var canonical string
+		if err := rows.Scan(&canonical); err != nil {
+			return "", err
+		}
+		return canonical, rows.Err()
+	}
+	return name, rows.Err()
+}
+
+// setTagAliases replaces all aliases for a tag with the given list.
+func (s *PostgresSQLStore) setTagAliases(ctx context.Context, exec bob.Executor, tagID uuid.UUID, aliases []string) error {
+	for _, alias := range aliases {
+		if alias == "" {
+			continue
+		}
+		rows, err := exec.QueryContext(ctx, "SELECT COUNT(*) FROM tags WHERE name = $1", alias)
+		if err != nil {
+			return err
+		}
+		var count int
+		if rows.Next() {
+			err = rows.Scan(&count)
+		}
+		closeErr := rows.Close()
+		if err != nil {
+			return err
+		}
+		if closeErr != nil {
+			return closeErr
+		}
+		if count > 0 {
+			return fmt.Errorf("%w: %q", ErrAliasConflict, alias)
+		}
+	}
+
+	_, err := exec.ExecContext(ctx, "DELETE FROM tag_aliases WHERE tag_id = $1", tagID)
+	if err != nil {
+		return err
+	}
+	for _, alias := range aliases {
+		if alias == "" {
+			continue
+		}
+		_, err := exec.ExecContext(ctx,
+			"INSERT INTO tag_aliases (tag_id, alias_name) VALUES ($1, $2)",
+			tagID, alias,
+		)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *PostgresSQLStore) ConvertTagToAlias(ctx context.Context, sourceName, targetName string) (*ConvertTagToAliasResult, error) {
+	tx, err := s.db.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	// Look up source tag
+	var sourceID uuid.UUID
+	err = tx.QueryRowContext(ctx, "SELECT id FROM tags WHERE name = $1", sourceName).Scan(&sourceID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, fmt.Errorf("source tag %q: %w", sourceName, ErrNotFound)
+		}
+		return nil, err
+	}
+
+	// Look up target tag
+	var targetID uuid.UUID
+	err = tx.QueryRowContext(ctx, "SELECT id FROM tags WHERE name = $1", targetName).Scan(&targetID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, fmt.Errorf("target tag %q: %w", targetName, ErrNotFound)
+		}
+		return nil, err
+	}
+
+	// Re-tag posts: move source associations to target where target doesn't already exist
+	_, err = tx.ExecContext(ctx,
+		`UPDATE posts_tags SET tag_id = $1
+		 WHERE tag_id = $2
+		   AND NOT EXISTS (SELECT 1 FROM posts_tags pt2 WHERE pt2.post_id = posts_tags.post_id AND pt2.tag_id = $1)`,
+		targetID, sourceID,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// Delete remaining source associations
+	_, err = tx.ExecContext(ctx, "DELETE FROM posts_tags WHERE tag_id = $1", sourceID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Collect source aliases before deleting
+	aliasRows, err := tx.QueryContext(ctx, "SELECT alias_name FROM tag_aliases WHERE tag_id = $1", sourceID)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = aliasRows.Close() }()
+	var sourceAliases []string
+	for aliasRows.Next() {
+		var alias string
+		if err := aliasRows.Scan(&alias); err != nil {
+			return nil, err
+		}
+		sourceAliases = append(sourceAliases, alias)
+	}
+	if err := aliasRows.Err(); err != nil {
+		return nil, err
+	}
+
+	// Delete source tag (cascades aliases)
+	_, err = tx.ExecContext(ctx, "DELETE FROM tags WHERE id = $1", sourceID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Add source name + source aliases as aliases of target
+	allNewAliases := append([]string{sourceName}, sourceAliases...)
+	for _, alias := range allNewAliases {
+		_, err = tx.ExecContext(ctx,
+			"INSERT INTO tag_aliases (tag_id, alias_name) VALUES ($1, $2) ON CONFLICT DO NOTHING",
+			targetID, alias,
+		)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Read the target tag within the transaction
+	var tagName, tagDesc string
+	var tagCatID sql.Null[uuid.UUID]
+	var tagCreatedAt, tagUpdatedAt time.Time
+	err = tx.QueryRowContext(ctx,
+		"SELECT name, description, tag_category_id, created_at, updated_at FROM tags WHERE id = $1",
+		targetID,
+	).Scan(&tagName, &tagDesc, &tagCatID, &tagCreatedAt, &tagUpdatedAt)
+	if err != nil {
+		return nil, err
+	}
+
+	tag := &models.Tag{
+		ID:            targetID,
+		Name:          tagName,
+		Description:   tagDesc,
+		TagCategoryID: tagCatID,
+		CreatedAt:     tagCreatedAt,
+		UpdatedAt:     tagUpdatedAt,
+	}
+
+	// Load category name if present
+	if tagCatID.Valid {
+		var cn string
+		err = tx.QueryRowContext(ctx, "SELECT name FROM tag_categories WHERE id = $1", tagCatID.V).Scan(&cn)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return nil, err
+		}
+		if err == nil {
+			tag.R.TagCategory = &models.TagCategory{Name: cn}
+		}
+	}
+
+	// Read aliases
+	txAliasRows, err := tx.QueryContext(ctx, "SELECT alias_name FROM tag_aliases WHERE tag_id = $1 ORDER BY alias_name", targetID)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = txAliasRows.Close() }()
+	var targetAliases []string
+	for txAliasRows.Next() {
+		var a string
+		if err := txAliasRows.Scan(&a); err != nil {
+			return nil, err
+		}
+		targetAliases = append(targetAliases, a)
+	}
+	if err := txAliasRows.Err(); err != nil {
+		return nil, err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+
+	return &ConvertTagToAliasResult{
+		Tag:     tag,
+		Aliases: targetAliases,
+	}, nil
+}

--- a/internal/storage/memory/memory.go
+++ b/internal/storage/memory/memory.go
@@ -15,7 +15,7 @@ type entry struct {
 	contentType string
 }
 
-// Storage is an in-memory storage.Storage implementation for testing.
+// Storage is an in-memory storage.MediaStore implementation for testing.
 type Storage struct {
 	mu      sync.Mutex
 	objects map[string]entry
@@ -37,14 +37,14 @@ func (s *Storage) Upload(_ context.Context, key string, data []byte, contentType
 	return "http://fake-storage/" + key, nil
 }
 
-func (s *Storage) Download(_ context.Context, key string) (*storage.Object, error) {
+func (s *Storage) Download(_ context.Context, key string) (*storage.Media, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	entry, ok := s.objects[key]
 	if !ok {
 		return nil, fmt.Errorf("object not found: %s", key)
 	}
-	return &storage.Object{
+	return &storage.Media{
 		Body:          io.NopCloser(strings.NewReader(string(entry.data))),
 		ContentType:   entry.contentType,
 		ContentLength: int64(len(entry.data)),

--- a/internal/storage/s3/s3.go
+++ b/internal/storage/s3/s3.go
@@ -15,7 +15,7 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-// Storage implements storage.Storage using an S3-compatible object store.
+// Storage implements storage.MediaStore using an S3-compatible object store.
 type Storage struct {
 	client   *s3.Client
 	bucket   string
@@ -113,7 +113,7 @@ func (st *Storage) Upload(ctx context.Context, key string, data []byte, contentT
 }
 
 // Download retrieves an object by key.
-func (st *Storage) Download(ctx context.Context, key string) (*storage.Object, error) {
+func (st *Storage) Download(ctx context.Context, key string) (*storage.Media, error) {
 	out, err := st.client.GetObject(ctx, &s3.GetObjectInput{
 		Bucket: aws.String(st.bucket),
 		Key:    aws.String(key),
@@ -129,7 +129,7 @@ func (st *Storage) Download(ctx context.Context, key string) (*storage.Object, e
 	if out.ContentLength != nil {
 		cl = *out.ContentLength
 	}
-	return &storage.Object{Body: out.Body, ContentType: ct, ContentLength: cl}, nil
+	return &storage.Media{Body: out.Body, ContentType: ct, ContentLength: cl}, nil
 }
 
 // Delete removes an object at the given key.

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -5,17 +5,17 @@ import (
 	"io"
 )
 
-// Object holds the data returned from a Download call.
-type Object struct {
+// Media holds the data returned from a Download call.
+type Media struct {
 	Body          io.ReadCloser
 	ContentType   string
 	ContentLength int64
 }
 
-// Storage is the interface for object storage operations.
-type Storage interface {
+// MediaStore is the interface for object storage operations.
+type MediaStore interface {
 	Ping(ctx context.Context) error
 	Upload(ctx context.Context, key string, data []byte, contentType string) (url string, err error)
-	Download(ctx context.Context, key string) (*Object, error)
+	Download(ctx context.Context, key string) (*Media, error)
 	Delete(ctx context.Context, key string) error
 }


### PR DESCRIPTION
## Summary
- Introduce `SQLStore` interface in `internal/db/store/` with per-resource sub-interfaces (`NoteStore`, `TagStore`, `TagCategoryStore`, `PostStore`, `Pinger`), backed by `PostgresSQLStore`
- Move all Bob ORM queries, transactions, and raw SQL from API handlers into store methods, making handlers thin routing/response layers
- Rename `storage.Storage` → `storage.MediaStore` and `store.Store` → `store.SQLStore` to disambiguate the two abstractions

## Test plan
- [x] `go build ./...` passes
- [x] `make lint` — 0 issues
- [x] `go test ./...` — all existing integration tests pass
- [x] `make build-images` — all three container images build successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)