### PR TITLE
Publish container images on semver git tags

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
     branches: [main]
+    tags: ["v[0-9]+.[0-9]+.[0-9]+"]
   pull_request:
     branches: [main]
 
@@ -39,7 +40,7 @@ jobs:
       - uses: golangci/golangci-lint-action@v9
 
   publish:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
     needs: [style, test, lint]
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
- Adds `tags` trigger to CI workflow for semver tags matching `v*.*.*`
- Updates `publish` job condition to also run on semver tag pushes
- `docker/metadata-action` automatically generates `1.2.3`, `1.2`, `1`, and `latest` image tags from the git tag

## Test plan
- [ ] Push a semver tag (e.g. `v0.1.0`) and verify images are published with version tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)