### PR TITLE
Make quadlet host ports configurable and remove unnecessary published ports

### DIFF
--- a/deploy/quadlet/hyperboard-api.container
+++ b/deploy/quadlet/hyperboard-api.container
@@ -20,7 +20,7 @@ Environment=HYPERBOARD_API_STORAGE_SECRET_KEY=${HYPERBOARD_STORAGE_SECRET_KEY}
 Environment=HYPERBOARD_API_STORAGE_REGION=${HYPERBOARD_STORAGE_REGION}
 Environment=HYPERBOARD_API_STORAGE_USE_PATH_STYLE=true
 Environment=HYPERBOARD_API_LOG_LEVEL=info
-PublishPort=8081:8080
+PublishPort=${HYPERBOARD_API_PORT}:8080
 HealthCmd=curl -f http://localhost:8080/healthz || exit 1
 HealthInterval=5s
 HealthTimeout=3s

--- a/deploy/quadlet/hyperboard-postgresql.container
+++ b/deploy/quadlet/hyperboard-postgresql.container
@@ -10,7 +10,6 @@ Volume=${HYPERBOARD_POSTGRESQL_DATA_DIR}:/var/lib/postgresql/data
 Environment=POSTGRES_USER=${HYPERBOARD_DB_USER}
 Environment=POSTGRES_PASSWORD=${HYPERBOARD_DB_PASSWORD}
 Environment=POSTGRES_DB=${HYPERBOARD_DB_NAME}
-PublishPort=5432:5432
 HealthCmd=pg_isready -U ${HYPERBOARD_DB_USER} -d ${HYPERBOARD_DB_NAME}
 HealthInterval=5s
 HealthTimeout=5s

--- a/deploy/quadlet/hyperboard-rustfs.container
+++ b/deploy/quadlet/hyperboard-rustfs.container
@@ -11,9 +11,8 @@ Exec=/data
 Environment=RUSTFS_ACCESS_KEY=${HYPERBOARD_STORAGE_ACCESS_KEY}
 Environment=RUSTFS_SECRET_KEY=${HYPERBOARD_STORAGE_SECRET_KEY}
 Environment=RUSTFS_CONSOLE_ENABLE=true
-PublishPort=9000:9000
-PublishPort=9001:9001
-HealthCmd=curl -f http://localhost:9000/health/ready || exit 1
+PublishPort=${HYPERBOARD_STORAGE_PORT}:9000
+HealthCmd=curl -f http://localhost:9000/health || exit 1
 HealthInterval=5s
 HealthTimeout=3s
 HealthRetries=5

--- a/deploy/quadlet/hyperboard-web.container
+++ b/deploy/quadlet/hyperboard-web.container
@@ -10,7 +10,7 @@ Network=hyperboard.network
 Environment=HYPERBOARD_WEB_ADMIN_PASSWORD=${HYPERBOARD_ADMIN_PASSWORD}
 Environment=HYPERBOARD_WEB_API_URL=http://hyperboard-api:8080
 Environment=HYPERBOARD_WEB_LOG_LEVEL=info
-PublishPort=8080:8080
+PublishPort=${HYPERBOARD_WEB_PORT}:8080
 
 [Service]
 EnvironmentFile=/etc/hyperboard/hyperboard.env

--- a/deploy/quadlet/hyperboard.env
+++ b/deploy/quadlet/hyperboard.env
@@ -1,3 +1,8 @@
+# Host ports
+HYPERBOARD_WEB_PORT=8080
+HYPERBOARD_API_PORT=8081
+HYPERBOARD_STORAGE_PORT=9000
+
 # Data storage directories - customize these paths for your deployment
 HYPERBOARD_POSTGRESQL_DATA_DIR=/var/lib/hyperboard/postgresql
 HYPERBOARD_RUSTFS_DATA_DIR=/var/lib/hyperboard/rustfs


### PR DESCRIPTION
## Summary

- Remove PostgreSQL host port (internal service, no external access needed)
- Remove RustFS dashboard port 9001 (unnecessary host exposure)
- Parameterize web, API, and S3 host ports via `HYPERBOARD_WEB_PORT`, `HYPERBOARD_API_PORT`, and `HYPERBOARD_STORAGE_PORT` in `hyperboard.env`, with existing values as defaults
- Fix RustFS health check to use `/health` (liveness) instead of `/health/ready` (Kubernetes readiness)

🤖 Generated with [Claude Code](https://claude.com/claude-code)