### PR TITLE
Disable CGO to fix container exec errors

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -9,6 +9,7 @@ def go_build(name, os, arch):
         name + "-bin",
         ['go', 'build', '-o', 'bin/{}'.format(name), './cmd/{}'.format(name)],
         env={
+            'CGO_ENABLED': '0',
             'GOOS': os,
             'GOARCH': arch,
         },

--- a/build/Containerfile
+++ b/build/Containerfile
@@ -17,15 +17,15 @@ COPY pkg/ pkg/
 
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o /bin/hyperboard-api ./cmd/hyperboard-api
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o /bin/hyperboard-api ./cmd/hyperboard-api
 
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o /bin/hyperboard-web ./cmd/hyperboard-web
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o /bin/hyperboard-web ./cmd/hyperboard-web
 
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o /bin/hyperboardctl ./cmd/hyperboardctl
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o /bin/hyperboardctl ./cmd/hyperboardctl
 
 FROM debian:13-slim AS hyperboard-api
 RUN apt-get update && \


### PR DESCRIPTION
## Summary
- Set `CGO_ENABLED=0` for all Go builds in the Containerfile and Tiltfile
- Fixes `exec /hyperboard-web: no such file or directory` caused by dynamically linked binaries running in `distroless/static` and `scratch` containers that lack a dynamic linker

🤖 Generated with [Claude Code](https://claude.com/claude-code)