### PR TITLE
Make file size and image clickable to open raw media

### DIFF
--- a/cmd/hyperboard-web/static/style.css
+++ b/cmd/hyperboard-web/static/style.css
@@ -255,6 +255,10 @@ button:hover,
   margin-right: auto;
 }
 
+.post-media-info a {
+  color: inherit;
+}
+
 .media-mode-option {
   color: var(--base03);
   cursor: pointer;

--- a/cmd/hyperboard-web/templates/post.html
+++ b/cmd/hyperboard-web/templates/post.html
@@ -5,7 +5,7 @@
 {{define "content"}}
 {{if .Error}}<div class="alert-error">{{.Error}}</div>{{end}}
 <div class="post-media-controls">
-  <span class="post-media-info">{{.Post.MimeType}}{{if .FileSize}} · {{.FileSize | formatSize}}{{end}}</span>
+  <span class="post-media-info">{{.Post.MimeType}}{{if .FileSize}} · <a href="{{.Post.ContentUrl | mediaUrl}}">{{.FileSize | formatSize}}</a>{{end}}</span>
   <span id="media-mode-fit" class="media-mode-option media-mode-option--active" onclick="setMediaMode('fit')">Fit</span>
   <span class="media-mode-sep">/</span>
   <span id="media-mode-fill" class="media-mode-option" onclick="setMediaMode('fill')">Fill</span>
@@ -14,7 +14,7 @@
   {{if .IsVideo}}
   <video controls src="{{.Post.ContentUrl | mediaUrl}}"></video>
   {{else}}
-  <img src="{{.Post.ContentUrl | mediaUrl}}" alt="Post">
+  <a href="{{.Post.ContentUrl | mediaUrl}}"><img src="{{.Post.ContentUrl | mediaUrl}}" alt="Post"></a>
   {{end}}
 </div>
 <script>


### PR DESCRIPTION
## Summary
- File size text on the post page links to the raw media URL
- Images are wrapped in a link to open the raw media directly
- Videos are unchanged (they already have playback controls)
- Link inherits the existing gray color to avoid visual distraction

🤖 Generated with [Claude Code](https://claude.com/claude-code)