### PR TITLE
Parse tag filters at startup and propagate errors

### DIFF
--- a/cmd/hyperboard-web/config.go
+++ b/cmd/hyperboard-web/config.go
@@ -4,7 +4,8 @@ import (
 	"encoding/json"
 	"strings"
 
-	"github.com/rs/zerolog/log"
+	"fmt"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -15,7 +16,7 @@ type Config struct {
 	SessionSecret string
 	APIURL        string
 	LogLevel      string
-	TagFilters    string
+	TagFilters    []TagFilter
 }
 
 func bindConfig(cmd *cobra.Command) {
@@ -35,25 +36,28 @@ func bindConfig(cmd *cobra.Command) {
 	_ = viper.BindPFlags(flags)
 }
 
-func loadConfig() *Config {
+func loadConfig() (*Config, error) {
+	tagFilters, err := parseTagFilters(viper.GetString("tag-filters"))
+	if err != nil {
+		return nil, fmt.Errorf("parsing tag-filters: %w", err)
+	}
 	return &Config{
 		Port:          viper.GetString("port"),
 		AdminPassword: viper.GetString("admin-password"),
 		SessionSecret: viper.GetString("session-secret"),
 		APIURL:        viper.GetString("api-url"),
 		LogLevel:      viper.GetString("log-level"),
-		TagFilters:    viper.GetString("tag-filters"),
-	}
+		TagFilters:    tagFilters,
+	}, nil
 }
 
-func parseTagFilters(jsonStr string) []TagFilter {
+func parseTagFilters(jsonStr string) ([]TagFilter, error) {
 	if jsonStr == "" {
-		return nil
+		return nil, nil
 	}
 	var filters []TagFilter
 	if err := json.Unmarshal([]byte(jsonStr), &filters); err != nil {
-		log.Warn().Err(err).Msg("Failed to parse tag-filters JSON")
-		return nil
+		return nil, fmt.Errorf("invalid JSON %q: %w", jsonStr, err)
 	}
-	return filters
+	return filters, nil
 }

--- a/cmd/hyperboard-web/config_test.go
+++ b/cmd/hyperboard-web/config_test.go
@@ -10,7 +10,10 @@ func TestParseTagFilters(t *testing.T) {
 	t.Run("valid JSON", func(t *testing.T) {
 		t.Parallel()
 		input := `[{"label":"Rating","tags":["rating:safe","rating:questionable"]},{"label":"No AI","tags":["-ai_generated"]}]`
-		filters := parseTagFilters(input)
+		filters, err := parseTagFilters(input)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 		if len(filters) != 2 {
 			t.Fatalf("got %d filters, want 2", len(filters))
 		}
@@ -30,7 +33,10 @@ func TestParseTagFilters(t *testing.T) {
 
 	t.Run("empty string", func(t *testing.T) {
 		t.Parallel()
-		filters := parseTagFilters("")
+		filters, err := parseTagFilters("")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 		if filters != nil {
 			t.Errorf("got %v, want nil", filters)
 		}
@@ -38,9 +44,9 @@ func TestParseTagFilters(t *testing.T) {
 
 	t.Run("malformed JSON", func(t *testing.T) {
 		t.Parallel()
-		filters := parseTagFilters("{bad json")
-		if filters != nil {
-			t.Errorf("got %v, want nil", filters)
+		_, err := parseTagFilters("{bad json")
+		if err == nil {
+			t.Error("expected error for malformed JSON, got nil")
 		}
 	})
 }

--- a/cmd/hyperboard-web/handlers.go
+++ b/cmd/hyperboard-web/handlers.go
@@ -54,7 +54,7 @@ func (app *App) handlePosts(w http.ResponseWriter, r *http.Request) {
 		Posts:      posts,
 		NextCursor: nextCursor,
 		Search:     search,
-		TagFilters: parseTagFilters(app.cfg.TagFilters),
+		TagFilters: app.cfg.TagFilters,
 		Error:      loadErr,
 	}
 

--- a/cmd/hyperboard-web/handlers_test.go
+++ b/cmd/hyperboard-web/handlers_test.go
@@ -224,7 +224,7 @@ func TestHandlePosts_WithTagFilters(t *testing.T) {
 		}
 		http.NotFound(w, r)
 	}))
-	app.cfg.TagFilters = `[{"label":"Rating","tags":["rating:safe","rating:explicit"]}]`
+	app.cfg.TagFilters = []TagFilter{{Label: "Rating", Tags: []string{"rating:safe", "rating:explicit"}}}
 
 	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 	w := httptest.NewRecorder()

--- a/cmd/hyperboard-web/main.go
+++ b/cmd/hyperboard-web/main.go
@@ -63,7 +63,10 @@ type App struct {
 }
 
 func run() error {
-	cfg := loadConfig()
+	cfg, err := loadConfig()
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
 
 	level, err := zerolog.ParseLevel(cfg.LogLevel)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Parse tag filters once at startup instead of on every request
- Return errors from `parseTagFilters` and `loadConfig` instead of silently swallowing them
- Invalid tag filter JSON now prevents the service from starting with a clear error message
- Include raw input in error messages for easier debugging

🤖 Generated with [Claude Code](https://claude.com/claude-code)