### PR TITLE
Add cascading tags and improve transaction safety

### DIFF
--- a/cmd/hyperboard-web/handlers.go
+++ b/cmd/hyperboard-web/handlers.go
@@ -483,13 +483,18 @@ func (app *App) handleTagEdit(w http.ResponseWriter, r *http.Request) {
 		if tag.Aliases != nil {
 			aliases = *tag.Aliases
 		}
+		var cascadingTags []string
+		if tag.CascadingTags != nil {
+			cascadingTags = *tag.CascadingTags
+		}
 		app.renderTemplate(w, r, "tag_edit", TagEditData{
-			Tag:         tag,
-			Aliases:     aliases,
-			Categories:  cats,
-			CurrentName: name,
-			IsNew:       isNew,
-			Error:       strings.Join(errs, "; "),
+			Tag:           tag,
+			Aliases:       aliases,
+			CascadingTags: cascadingTags,
+			Categories:    cats,
+			CurrentName:   name,
+			IsNew:         isNew,
+			Error:         strings.Join(errs, "; "),
 		})
 
 	case http.MethodPost:
@@ -497,6 +502,7 @@ func (app *App) handleTagEdit(w http.ResponseWriter, r *http.Request) {
 		description := r.FormValue("description")
 		category := r.FormValue("category")
 		aliasesRaw := r.FormValue("aliases")
+		cascadingTagsRaw := r.FormValue("cascading_tags")
 
 		var aliases []string
 		for a := range strings.SplitSeq(aliasesRaw, ",") {
@@ -506,10 +512,19 @@ func (app *App) handleTagEdit(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
+		var cascadingTags []string
+		for ct := range strings.SplitSeq(cascadingTagsRaw, ",") {
+			ct = strings.TrimSpace(ct)
+			if ct != "" {
+				cascadingTags = append(cascadingTags, ct)
+			}
+		}
+
 		tag := types.Tag{
-			Name:        newName,
-			Description: description,
-			Aliases:     &aliases,
+			Name:          newName,
+			Description:   description,
+			Aliases:       &aliases,
+			CascadingTags: &cascadingTags,
 		}
 		if category != "" {
 			tag.Category = &category
@@ -528,12 +543,13 @@ func (app *App) handleTagEdit(w http.ResponseWriter, r *http.Request) {
 				errMsg = fmt.Sprintf("Failed to save tag: %s", resp.Body)
 			}
 			app.renderTemplate(w, r, "tag_edit", TagEditData{
-				Tag:         tag,
-				Aliases:     aliases,
-				Categories:  cats,
-				CurrentName: name,
-				IsNew:       isNew,
-				Error:       errMsg,
+				Tag:           tag,
+				Aliases:       aliases,
+				CascadingTags: cascadingTags,
+				Categories:    cats,
+				CurrentName:   name,
+				IsNew:         isNew,
+				Error:         errMsg,
 			})
 			return
 		}

--- a/cmd/hyperboard-web/static/style.css
+++ b/cmd/hyperboard-web/static/style.css
@@ -185,6 +185,14 @@ button:hover,
   margin-left: 0.4rem;
   cursor: pointer;
   color: var(--base08);
+  vertical-align: middle;
+}
+
+.badge-cascade {
+  background: transparent;
+  border-top: 1px solid var(--base02);
+  border-right: 1px solid var(--base02);
+  border-bottom: 1px solid var(--base02);
 }
 
 /* Posts grid */

--- a/cmd/hyperboard-web/templatedata.go
+++ b/cmd/hyperboard-web/templatedata.go
@@ -34,12 +34,13 @@ type TagsData struct {
 }
 
 type TagEditData struct {
-	Tag         types.Tag
-	Categories  []types.TagCategory
-	Aliases     []string
-	CurrentName string
-	IsNew       bool
-	Error       string
+	Tag           types.Tag
+	Categories    []types.TagCategory
+	Aliases       []string
+	CascadingTags []string
+	CurrentName   string
+	IsNew         bool
+	Error         string
 }
 
 type TagCategoriesData struct {

--- a/cmd/hyperboard-web/templates/post.html
+++ b/cmd/hyperboard-web/templates/post.html
@@ -96,7 +96,7 @@ function setMediaMode(mode) {
 
 {{define "post-tags"}}
 <div class="post-tags">
-  {{if .Post.Tags}}
+  {{if or .Post.Tags .Post.CascadingTags}}
   <div class="post-tags-list">
     {{range .Post.Tags}}
     <span class="badge">
@@ -104,6 +104,11 @@ function setMediaMode(mode) {
       <a class="badge-remove" hx-delete="/posts/{{$.Post.ID}}/tags/{{.}}" hx-target=".post-tags" hx-swap="outerHTML">×</a>
     </span>
     {{end}}
+    {{if .Post.CascadingTags}}{{range deref_strings .Post.CascadingTags}}
+    <span class="badge badge-cascade">
+      <a href="/?search={{.}}" class="badge-link">{{.}}</a>
+    </span>
+    {{end}}{{end}}
   </div>
   {{end}}
   <div class="post-tags-add">

--- a/cmd/hyperboard-web/templates/tag_edit.html
+++ b/cmd/hyperboard-web/templates/tag_edit.html
@@ -28,6 +28,11 @@
     <input type="text" name="aliases" value="{{join_strings .Aliases ", "}}" placeholder="comma-separated aliases">
     <span style="color:var(--base03);font-size:0.85rem">Typing an alias in search or tag add will resolve to this tag's canonical name.</span>
   </div>
+  <div class="form-group">
+    <label>Cascading Tags</label>
+    <input type="text" name="cascading_tags" value="{{join_strings .CascadingTags ", "}}" placeholder="comma-separated tag names">
+    <span style="color:var(--base03);font-size:0.85rem">Posts with this tag will also appear in searches for these tags.</span>
+  </div>
   <button type="submit" class="btn btn-primary">Save</button>
   {{if not .IsNew}}
   <button type="button" class="btn btn-danger"

--- a/cmd/hyperboard-web/templates/tags.html
+++ b/cmd/hyperboard-web/templates/tags.html
@@ -15,6 +15,7 @@
       <th class="sortable" data-sort="category" data-type="string">Category</th>
       <th class="sortable" data-sort="description" data-type="string">Description</th>
       <th class="sortable" data-sort="aliases" data-type="string">Aliases</th>
+      <th class="sortable" data-sort="cascading" data-type="string">Cascading Tags</th>
       <th class="sortable" data-sort="posts" data-type="number">Posts</th>
     </tr>
   </thead>
@@ -30,6 +31,9 @@
       <td data-value="{{.Description}}">{{.Description}}</td>
       <td data-value="{{if .Aliases}}{{join_strings (deref_strings .Aliases) ", "}}{{end}}" style="color:var(--base03);font-size:0.9rem">
         {{if .Aliases}}{{join_strings (deref_strings .Aliases) ", "}}{{end}}
+      </td>
+      <td data-value="{{if .CascadingTags}}{{join_strings (deref_strings .CascadingTags) ", "}}{{end}}" style="color:var(--base03);font-size:0.9rem">
+        {{if .CascadingTags}}{{join_strings (deref_strings .CascadingTags) ", "}}{{end}}
       </td>
       <td data-value="{{if .PostCount}}{{deref_int .PostCount}}{{else}}0{{end}}">
         {{if and .PostCount (gt (deref_int .PostCount) 0)}}

--- a/internal/api/posts.go
+++ b/internal/api/posts.go
@@ -184,7 +184,12 @@ func (s *Server) GetPosts(w http.ResponseWriter, r *http.Request, params GetPost
 
 		items := make([]types.Post, 0, len(posts))
 		for _, post := range posts {
-			items = append(items, postFromModel(post))
+			p := postFromModel(post)
+			ct, _ := s.sqlStore.GetPostCascadingTags(ctx, post.ID)
+			if len(ct) > 0 {
+				p.CascadingTags = &ct
+			}
+			items = append(items, p)
 		}
 		respond(w, http.StatusOK, PostsResponse{Items: &items, Cursor: nextCursor})
 		return
@@ -232,7 +237,12 @@ func (s *Server) GetPosts(w http.ResponseWriter, r *http.Request, params GetPost
 
 	items := make([]types.Post, 0, len(posts))
 	for _, post := range posts {
-		items = append(items, postFromModel(post))
+		p := postFromModel(post)
+		ct, _ := s.sqlStore.GetPostCascadingTags(ctx, post.ID)
+		if len(ct) > 0 {
+			p.CascadingTags = &ct
+		}
+		items = append(items, p)
 	}
 	respond(w, http.StatusOK, PostsResponse{Items: &items, Cursor: nextCursor})
 }
@@ -250,7 +260,17 @@ func (s *Server) GetPost(w http.ResponseWriter, r *http.Request, id Id) {
 		return
 	}
 
-	respond(w, http.StatusOK, postFromModel(model))
+	post := postFromModel(model)
+	cascadingTags, err := s.sqlStore.GetPostCascadingTags(ctx, uuid.UUID(id))
+	if err != nil {
+		respondWithError(w, http.StatusInternalServerError, "Failed to retrieve cascading tags")
+		return
+	}
+	if len(cascadingTags) > 0 {
+		post.CascadingTags = &cascadingTags
+	}
+
+	respond(w, http.StatusOK, post)
 }
 
 func (s *Server) UploadPost(w http.ResponseWriter, r *http.Request, params UploadPostParams) {

--- a/internal/api/spec/types-spec.yaml
+++ b/internal/api/spec/types-spec.yaml
@@ -38,6 +38,10 @@ components:
           type: array
           items:
             type: string
+        cascadingTags:
+          type: array
+          items:
+            $ref: "#/components/schemas/TagName"
         postCount:
           type: integer
         createdAt:
@@ -91,6 +95,10 @@ components:
         hasAudio:
           type: boolean
         tags:
+          type: array
+          items:
+            $ref: "#/components/schemas/TagName"
+        cascadingTags:
           type: array
           items:
             $ref: "#/components/schemas/TagName"

--- a/internal/api/tags.go
+++ b/internal/api/tags.go
@@ -88,6 +88,12 @@ func (s *Server) GetTags(w http.ResponseWriter, r *http.Request, params GetTagsP
 		return
 	}
 
+	cascadeMap, err := s.sqlStore.GetTagCascades(ctx, tagIDs...)
+	if err != nil {
+		respondWithError(w, http.StatusInternalServerError, "Failed to retrieve tag cascades")
+		return
+	}
+
 	var nextCursor *string
 	if hasMore {
 		encoded := obfuscateCursor(tags[len(tags)-1].Name)
@@ -105,6 +111,9 @@ func (s *Server) GetTags(w http.ResponseWriter, r *http.Request, params GetTagsP
 		}
 		if aliases, ok := aliasMap[tag.ID]; ok {
 			tagResp.Aliases = &aliases
+		}
+		if cascades, ok := cascadeMap[tag.ID]; ok {
+			tagResp.CascadingTags = &cascades
 		}
 		items = append(items, tagResp)
 	}
@@ -141,6 +150,15 @@ func (s *Server) GetTag(w http.ResponseWriter, r *http.Request, name Tag) {
 	}
 	if aliases, ok := aliasMap[model.ID]; ok {
 		tagResp.Aliases = &aliases
+	}
+
+	cascadeMap, err := s.sqlStore.GetTagCascades(ctx, model.ID)
+	if err != nil {
+		respondWithError(w, http.StatusInternalServerError, "Failed to load tag cascades")
+		return
+	}
+	if cascades, ok := cascadeMap[model.ID]; ok {
+		tagResp.CascadingTags = &cascades
 	}
 
 	respond(w, http.StatusOK, tagResp)
@@ -200,12 +218,18 @@ func (s *Server) PutTag(w http.ResponseWriter, r *http.Request, name Tag) {
 		aliases = *tag.Aliases
 	}
 
+	var cascadingTags []string
+	if tag.CascadingTags != nil {
+		cascadingTags = *tag.CascadingTags
+	}
+
 	now := time.Now().UTC()
 	resultModel, isCreate, err := s.sqlStore.UpsertTag(ctx, name, store.TagInput{
 		Name:          tag.Name,
 		Description:   tag.Description,
 		Category:      tag.Category,
 		Aliases:       aliases,
+		CascadingTags: cascadingTags,
 		TagCategoryID: tagCategoryID,
 	}, now)
 	if err != nil {
@@ -226,6 +250,15 @@ func (s *Server) PutTag(w http.ResponseWriter, r *http.Request, name Tag) {
 	}
 	if a, ok := aliasMap[resultModel.ID]; ok {
 		tagResp.Aliases = &a
+	}
+
+	cascadeMap, err := s.sqlStore.GetTagCascades(ctx, resultModel.ID)
+	if err != nil {
+		respondWithError(w, http.StatusInternalServerError, "Failed to load tag cascades")
+		return
+	}
+	if c, ok := cascadeMap[resultModel.ID]; ok {
+		tagResp.CascadingTags = &c
 	}
 
 	status := http.StatusOK

--- a/internal/db/errors/tag_cascades.bob.go
+++ b/internal/db/errors/tag_cascades.bob.go
@@ -1,0 +1,17 @@
+// Code generated . DO NOT EDIT.
+// This file is meant to be re-generated in place and/or deleted at any time.
+
+package errors
+
+var TagCascadeErrors = &tagCascadeErrors{
+	ErrUniqueTagCascadesPkey: &UniqueConstraintError{
+		schema:  "",
+		table:   "tag_cascades",
+		columns: []string{"tag_id", "cascaded_tag_id"},
+		s:       "tag_cascades_pkey",
+	},
+}
+
+type tagCascadeErrors struct {
+	ErrUniqueTagCascadesPkey *UniqueConstraintError
+}

--- a/internal/db/factory/bobfactory_context.bob.go
+++ b/internal/db/factory/bobfactory_context.bob.go
@@ -24,6 +24,11 @@ var (
 	tagAliasWithParentsCascadingCtx = newContextual[bool]("tagAliasWithParentsCascading")
 	tagAliasRelTagCtx               = newContextual[bool]("tag_aliases.tags.tag_aliases.tag_aliases_tag_id_fkey")
 
+	// Relationship Contexts for tag_cascades
+	tagCascadeWithParentsCascadingCtx = newContextual[bool]("tagCascadeWithParentsCascading")
+	tagCascadeRelCascadedTagTagCtx    = newContextual[bool]("tag_cascades.tags.tag_cascades.tag_cascades_cascaded_tag_id_fkey")
+	tagCascadeRelTagCtx               = newContextual[bool]("tag_cascades.tags.tag_cascades.tag_cascades_tag_id_fkey")
+
 	// Relationship Contexts for tag_categories
 	tagCategoryWithParentsCascadingCtx = newContextual[bool]("tagCategoryWithParentsCascading")
 	tagCategoryRelTagsCtx              = newContextual[bool]("tag_categories.tags.tags.tags_tag_category_id_fkey")
@@ -32,6 +37,7 @@ var (
 	tagWithParentsCascadingCtx = newContextual[bool]("tagWithParentsCascading")
 	tagRelPostsCtx             = newContextual[bool]("posts.tags.posts_tags.posts_tags_post_id_fkeyposts_tags.posts_tags_tag_id_fkey")
 	tagRelTagAliasesCtx        = newContextual[bool]("tag_aliases.tags.tag_aliases.tag_aliases_tag_id_fkey")
+	tagRelTagsCtx              = newContextual[bool]("tags.tags.tag_cascades.tag_cascades_cascaded_tag_id_fkeytag_cascades.tag_cascades_tag_id_fkey")
 	tagRelTagCategoryCtx       = newContextual[bool]("tag_categories.tags.tags.tags_tag_category_id_fkey")
 )
 

--- a/internal/db/factory/bobfactory_main.bob.go
+++ b/internal/db/factory/bobfactory_main.bob.go
@@ -17,6 +17,7 @@ type Factory struct {
 	basePostMods        PostModSlice
 	basePostsTagMods    PostsTagModSlice
 	baseTagAliasMods    TagAliasModSlice
+	baseTagCascadeMods  TagCascadeModSlice
 	baseTagCategoryMods TagCategoryModSlice
 	baseTagMods         TagModSlice
 }
@@ -156,6 +157,39 @@ func (f *Factory) FromExistingTagAlias(m *models.TagAlias) *TagAliasTemplate {
 	return o
 }
 
+func (f *Factory) NewTagCascade(mods ...TagCascadeMod) *TagCascadeTemplate {
+	return f.NewTagCascadeWithContext(context.Background(), mods...)
+}
+
+func (f *Factory) NewTagCascadeWithContext(ctx context.Context, mods ...TagCascadeMod) *TagCascadeTemplate {
+	o := &TagCascadeTemplate{f: f}
+
+	if f != nil {
+		f.baseTagCascadeMods.Apply(ctx, o)
+	}
+
+	TagCascadeModSlice(mods).Apply(ctx, o)
+
+	return o
+}
+
+func (f *Factory) FromExistingTagCascade(m *models.TagCascade) *TagCascadeTemplate {
+	o := &TagCascadeTemplate{f: f, alreadyPersisted: true}
+
+	o.TagID = func() uuid.UUID { return m.TagID }
+	o.CascadedTagID = func() uuid.UUID { return m.CascadedTagID }
+
+	ctx := context.Background()
+	if m.R.CascadedTagTag != nil {
+		TagCascadeMods.WithExistingCascadedTagTag(m.R.CascadedTagTag).Apply(ctx, o)
+	}
+	if m.R.Tag != nil {
+		TagCascadeMods.WithExistingTag(m.R.Tag).Apply(ctx, o)
+	}
+
+	return o
+}
+
 func (f *Factory) NewTagCategory(mods ...TagCategoryMod) *TagCategoryTemplate {
 	return f.NewTagCategoryWithContext(context.Background(), mods...)
 }
@@ -223,6 +257,9 @@ func (f *Factory) FromExistingTag(m *models.Tag) *TagTemplate {
 	if len(m.R.TagAliases) > 0 {
 		TagMods.AddExistingTagAliases(m.R.TagAliases...).Apply(ctx, o)
 	}
+	if len(m.R.Tags) > 0 {
+		TagMods.AddExistingTags(m.R.Tags...).Apply(ctx, o)
+	}
 	if m.R.TagCategory != nil {
 		TagMods.WithExistingTagCategory(m.R.TagCategory).Apply(ctx, o)
 	}
@@ -260,6 +297,14 @@ func (f *Factory) ClearBaseTagAliasMods() {
 
 func (f *Factory) AddBaseTagAliasMod(mods ...TagAliasMod) {
 	f.baseTagAliasMods = append(f.baseTagAliasMods, mods...)
+}
+
+func (f *Factory) ClearBaseTagCascadeMods() {
+	f.baseTagCascadeMods = nil
+}
+
+func (f *Factory) AddBaseTagCascadeMod(mods ...TagCascadeMod) {
+	f.baseTagCascadeMods = append(f.baseTagCascadeMods, mods...)
 }
 
 func (f *Factory) ClearBaseTagCategoryMods() {

--- a/internal/db/factory/bobfactory_main.bob_test.go
+++ b/internal/db/factory/bobfactory_main.bob_test.go
@@ -104,6 +104,30 @@ func TestCreateTagAlias(t *testing.T) {
 	}
 }
 
+func TestCreateTagCascade(t *testing.T) {
+	if testDB == nil {
+		t.Skip("skipping test, no DSN provided")
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	tx, err := testDB.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Error starting transaction: %v", err)
+	}
+
+	defer func() {
+		if err := tx.Rollback(ctx); err != nil {
+			t.Fatalf("Error rolling back transaction: %v", err)
+		}
+	}()
+
+	if _, err := New().NewTagCascadeWithContext(ctx).Create(ctx, tx); err != nil {
+		t.Fatalf("Error creating TagCascade: %v", err)
+	}
+}
+
 func TestCreateTagCategory(t *testing.T) {
 	if testDB == nil {
 		t.Skip("skipping test, no DSN provided")

--- a/internal/db/factory/tag_cascades.bob.go
+++ b/internal/db/factory/tag_cascades.bob.go
@@ -1,0 +1,431 @@
+// Code generated . DO NOT EDIT.
+// This file is meant to be re-generated in place and/or deleted at any time.
+
+package factory
+
+import (
+	"context"
+	"testing"
+
+	models "github.com/dharmab/hyperboard/internal/db/models"
+	"github.com/gofrs/uuid/v5"
+	"github.com/jaswdr/faker/v2"
+	"github.com/stephenafamo/bob"
+)
+
+type TagCascadeMod interface {
+	Apply(context.Context, *TagCascadeTemplate)
+}
+
+type TagCascadeModFunc func(context.Context, *TagCascadeTemplate)
+
+func (f TagCascadeModFunc) Apply(ctx context.Context, n *TagCascadeTemplate) {
+	f(ctx, n)
+}
+
+type TagCascadeModSlice []TagCascadeMod
+
+func (mods TagCascadeModSlice) Apply(ctx context.Context, n *TagCascadeTemplate) {
+	for _, f := range mods {
+		f.Apply(ctx, n)
+	}
+}
+
+// TagCascadeTemplate is an object representing the database table.
+// all columns are optional and should be set by mods
+type TagCascadeTemplate struct {
+	TagID         func() uuid.UUID
+	CascadedTagID func() uuid.UUID
+
+	r tagCascadeR
+	f *Factory
+
+	alreadyPersisted bool
+}
+
+type tagCascadeR struct {
+	CascadedTagTag *tagCascadeRCascadedTagTagR
+	Tag            *tagCascadeRTagR
+}
+
+type tagCascadeRCascadedTagTagR struct {
+	o *TagTemplate
+}
+type tagCascadeRTagR struct {
+	o *TagTemplate
+}
+
+// Apply mods to the TagCascadeTemplate
+func (o *TagCascadeTemplate) Apply(ctx context.Context, mods ...TagCascadeMod) {
+	for _, mod := range mods {
+		mod.Apply(ctx, o)
+	}
+}
+
+// setModelRels creates and sets the relationships on *models.TagCascade
+// according to the relationships in the template. Nothing is inserted into the db
+func (t TagCascadeTemplate) setModelRels(o *models.TagCascade) {
+	if t.r.CascadedTagTag != nil {
+		rel := t.r.CascadedTagTag.o.Build()
+		o.CascadedTagID = rel.ID // h2
+		o.R.CascadedTagTag = rel
+	}
+
+	if t.r.Tag != nil {
+		rel := t.r.Tag.o.Build()
+		o.TagID = rel.ID // h2
+		o.R.Tag = rel
+	}
+}
+
+// BuildSetter returns an *models.TagCascadeSetter
+// this does nothing with the relationship templates
+func (o TagCascadeTemplate) BuildSetter() *models.TagCascadeSetter {
+	m := &models.TagCascadeSetter{}
+
+	if o.TagID != nil {
+		val := o.TagID()
+		m.TagID = func() *uuid.UUID { return &val }()
+	}
+	if o.CascadedTagID != nil {
+		val := o.CascadedTagID()
+		m.CascadedTagID = func() *uuid.UUID { return &val }()
+	}
+
+	return m
+}
+
+// BuildManySetter returns an []*models.TagCascadeSetter
+// this does nothing with the relationship templates
+func (o TagCascadeTemplate) BuildManySetter(number int) []*models.TagCascadeSetter {
+	m := make([]*models.TagCascadeSetter, number)
+
+	for i := range m {
+		m[i] = o.BuildSetter()
+	}
+
+	return m
+}
+
+// Build returns an *models.TagCascade
+// Related objects are also created and placed in the .R field
+// NOTE: Objects are not inserted into the database. Use TagCascadeTemplate.Create
+func (o TagCascadeTemplate) Build() *models.TagCascade {
+	m := &models.TagCascade{}
+
+	if o.TagID != nil {
+		m.TagID = o.TagID()
+	}
+	if o.CascadedTagID != nil {
+		m.CascadedTagID = o.CascadedTagID()
+	}
+
+	o.setModelRels(m)
+
+	return m
+}
+
+// BuildMany returns an models.TagCascadeSlice
+// Related objects are also created and placed in the .R field
+// NOTE: Objects are not inserted into the database. Use TagCascadeTemplate.CreateMany
+func (o TagCascadeTemplate) BuildMany(number int) models.TagCascadeSlice {
+	m := make(models.TagCascadeSlice, number)
+
+	for i := range m {
+		m[i] = o.Build()
+	}
+
+	return m
+}
+
+func ensureCreatableTagCascade(m *models.TagCascadeSetter) {
+	if !(m.TagID != nil) {
+		val := random_uuid_UUID(nil)
+		m.TagID = func() *uuid.UUID { return &val }()
+	}
+	if !(m.CascadedTagID != nil) {
+		val := random_uuid_UUID(nil)
+		m.CascadedTagID = func() *uuid.UUID { return &val }()
+	}
+}
+
+// insertOptRels creates and inserts any optional the relationships on *models.TagCascade
+// according to the relationships in the template.
+// any required relationship should have already exist on the model
+func (o *TagCascadeTemplate) insertOptRels(ctx context.Context, exec bob.Executor, m *models.TagCascade) error {
+	var err error
+
+	return err
+}
+
+// Create builds a tagCascade and inserts it into the database
+// Relations objects are also inserted and placed in the .R field
+func (o *TagCascadeTemplate) Create(ctx context.Context, exec bob.Executor) (*models.TagCascade, error) {
+	var err error
+	opt := o.BuildSetter()
+	ensureCreatableTagCascade(opt)
+
+	if o.r.CascadedTagTag == nil {
+		TagCascadeMods.WithNewCascadedTagTag().Apply(ctx, o)
+	}
+
+	var rel0 *models.Tag
+
+	if o.r.CascadedTagTag.o.alreadyPersisted {
+		rel0 = o.r.CascadedTagTag.o.Build()
+	} else {
+		rel0, err = o.r.CascadedTagTag.o.Create(ctx, exec)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	opt.CascadedTagID = func() *uuid.UUID { return &rel0.ID }()
+
+	if o.r.Tag == nil {
+		TagCascadeMods.WithNewTag().Apply(ctx, o)
+	}
+
+	var rel1 *models.Tag
+
+	if o.r.Tag.o.alreadyPersisted {
+		rel1 = o.r.Tag.o.Build()
+	} else {
+		rel1, err = o.r.Tag.o.Create(ctx, exec)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	opt.TagID = func() *uuid.UUID { return &rel1.ID }()
+
+	m, err := models.TagCascades.Insert(opt).One(ctx, exec)
+	if err != nil {
+		return nil, err
+	}
+
+	m.R.CascadedTagTag = rel0
+	m.R.Tag = rel1
+
+	if err := o.insertOptRels(ctx, exec, m); err != nil {
+		return nil, err
+	}
+	return m, err
+}
+
+// MustCreate builds a tagCascade and inserts it into the database
+// Relations objects are also inserted and placed in the .R field
+// panics if an error occurs
+func (o *TagCascadeTemplate) MustCreate(ctx context.Context, exec bob.Executor) *models.TagCascade {
+	m, err := o.Create(ctx, exec)
+	if err != nil {
+		panic(err)
+	}
+	return m
+}
+
+// CreateOrFail builds a tagCascade and inserts it into the database
+// Relations objects are also inserted and placed in the .R field
+// It calls `tb.Fatal(err)` on the test/benchmark if an error occurs
+func (o *TagCascadeTemplate) CreateOrFail(ctx context.Context, tb testing.TB, exec bob.Executor) *models.TagCascade {
+	tb.Helper()
+	m, err := o.Create(ctx, exec)
+	if err != nil {
+		tb.Fatal(err)
+		return nil
+	}
+	return m
+}
+
+// CreateMany builds multiple tagCascades and inserts them into the database
+// Relations objects are also inserted and placed in the .R field
+func (o TagCascadeTemplate) CreateMany(ctx context.Context, exec bob.Executor, number int) (models.TagCascadeSlice, error) {
+	var err error
+	m := make(models.TagCascadeSlice, number)
+
+	for i := range m {
+		m[i], err = o.Create(ctx, exec)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return m, nil
+}
+
+// MustCreateMany builds multiple tagCascades and inserts them into the database
+// Relations objects are also inserted and placed in the .R field
+// panics if an error occurs
+func (o TagCascadeTemplate) MustCreateMany(ctx context.Context, exec bob.Executor, number int) models.TagCascadeSlice {
+	m, err := o.CreateMany(ctx, exec, number)
+	if err != nil {
+		panic(err)
+	}
+	return m
+}
+
+// CreateManyOrFail builds multiple tagCascades and inserts them into the database
+// Relations objects are also inserted and placed in the .R field
+// It calls `tb.Fatal(err)` on the test/benchmark if an error occurs
+func (o TagCascadeTemplate) CreateManyOrFail(ctx context.Context, tb testing.TB, exec bob.Executor, number int) models.TagCascadeSlice {
+	tb.Helper()
+	m, err := o.CreateMany(ctx, exec, number)
+	if err != nil {
+		tb.Fatal(err)
+		return nil
+	}
+	return m
+}
+
+// TagCascade has methods that act as mods for the TagCascadeTemplate
+var TagCascadeMods tagCascadeMods
+
+type tagCascadeMods struct{}
+
+func (m tagCascadeMods) RandomizeAllColumns(f *faker.Faker) TagCascadeMod {
+	return TagCascadeModSlice{
+		TagCascadeMods.RandomTagID(f),
+		TagCascadeMods.RandomCascadedTagID(f),
+	}
+}
+
+// Set the model columns to this value
+func (m tagCascadeMods) TagID(val uuid.UUID) TagCascadeMod {
+	return TagCascadeModFunc(func(_ context.Context, o *TagCascadeTemplate) {
+		o.TagID = func() uuid.UUID { return val }
+	})
+}
+
+// Set the Column from the function
+func (m tagCascadeMods) TagIDFunc(f func() uuid.UUID) TagCascadeMod {
+	return TagCascadeModFunc(func(_ context.Context, o *TagCascadeTemplate) {
+		o.TagID = f
+	})
+}
+
+// Clear any values for the column
+func (m tagCascadeMods) UnsetTagID() TagCascadeMod {
+	return TagCascadeModFunc(func(_ context.Context, o *TagCascadeTemplate) {
+		o.TagID = nil
+	})
+}
+
+// Generates a random value for the column using the given faker
+// if faker is nil, a default faker is used
+func (m tagCascadeMods) RandomTagID(f *faker.Faker) TagCascadeMod {
+	return TagCascadeModFunc(func(_ context.Context, o *TagCascadeTemplate) {
+		o.TagID = func() uuid.UUID {
+			return random_uuid_UUID(f)
+		}
+	})
+}
+
+// Set the model columns to this value
+func (m tagCascadeMods) CascadedTagID(val uuid.UUID) TagCascadeMod {
+	return TagCascadeModFunc(func(_ context.Context, o *TagCascadeTemplate) {
+		o.CascadedTagID = func() uuid.UUID { return val }
+	})
+}
+
+// Set the Column from the function
+func (m tagCascadeMods) CascadedTagIDFunc(f func() uuid.UUID) TagCascadeMod {
+	return TagCascadeModFunc(func(_ context.Context, o *TagCascadeTemplate) {
+		o.CascadedTagID = f
+	})
+}
+
+// Clear any values for the column
+func (m tagCascadeMods) UnsetCascadedTagID() TagCascadeMod {
+	return TagCascadeModFunc(func(_ context.Context, o *TagCascadeTemplate) {
+		o.CascadedTagID = nil
+	})
+}
+
+// Generates a random value for the column using the given faker
+// if faker is nil, a default faker is used
+func (m tagCascadeMods) RandomCascadedTagID(f *faker.Faker) TagCascadeMod {
+	return TagCascadeModFunc(func(_ context.Context, o *TagCascadeTemplate) {
+		o.CascadedTagID = func() uuid.UUID {
+			return random_uuid_UUID(f)
+		}
+	})
+}
+
+func (m tagCascadeMods) WithParentsCascading() TagCascadeMod {
+	return TagCascadeModFunc(func(ctx context.Context, o *TagCascadeTemplate) {
+		if isDone, _ := tagCascadeWithParentsCascadingCtx.Value(ctx); isDone {
+			return
+		}
+		ctx = tagCascadeWithParentsCascadingCtx.WithValue(ctx, true)
+		{
+
+			related := o.f.NewTagWithContext(ctx, TagMods.WithParentsCascading())
+			m.WithCascadedTagTag(related).Apply(ctx, o)
+		}
+		{
+
+			related := o.f.NewTagWithContext(ctx, TagMods.WithParentsCascading())
+			m.WithTag(related).Apply(ctx, o)
+		}
+	})
+}
+
+func (m tagCascadeMods) WithCascadedTagTag(rel *TagTemplate) TagCascadeMod {
+	return TagCascadeModFunc(func(ctx context.Context, o *TagCascadeTemplate) {
+		o.r.CascadedTagTag = &tagCascadeRCascadedTagTagR{
+			o: rel,
+		}
+	})
+}
+
+func (m tagCascadeMods) WithNewCascadedTagTag(mods ...TagMod) TagCascadeMod {
+	return TagCascadeModFunc(func(ctx context.Context, o *TagCascadeTemplate) {
+		related := o.f.NewTagWithContext(ctx, mods...)
+
+		m.WithCascadedTagTag(related).Apply(ctx, o)
+	})
+}
+
+func (m tagCascadeMods) WithExistingCascadedTagTag(em *models.Tag) TagCascadeMod {
+	return TagCascadeModFunc(func(ctx context.Context, o *TagCascadeTemplate) {
+		o.r.CascadedTagTag = &tagCascadeRCascadedTagTagR{
+			o: o.f.FromExistingTag(em),
+		}
+	})
+}
+
+func (m tagCascadeMods) WithoutCascadedTagTag() TagCascadeMod {
+	return TagCascadeModFunc(func(ctx context.Context, o *TagCascadeTemplate) {
+		o.r.CascadedTagTag = nil
+	})
+}
+
+func (m tagCascadeMods) WithTag(rel *TagTemplate) TagCascadeMod {
+	return TagCascadeModFunc(func(ctx context.Context, o *TagCascadeTemplate) {
+		o.r.Tag = &tagCascadeRTagR{
+			o: rel,
+		}
+	})
+}
+
+func (m tagCascadeMods) WithNewTag(mods ...TagMod) TagCascadeMod {
+	return TagCascadeModFunc(func(ctx context.Context, o *TagCascadeTemplate) {
+		related := o.f.NewTagWithContext(ctx, mods...)
+
+		m.WithTag(related).Apply(ctx, o)
+	})
+}
+
+func (m tagCascadeMods) WithExistingTag(em *models.Tag) TagCascadeMod {
+	return TagCascadeModFunc(func(ctx context.Context, o *TagCascadeTemplate) {
+		o.r.Tag = &tagCascadeRTagR{
+			o: o.f.FromExistingTag(em),
+		}
+	})
+}
+
+func (m tagCascadeMods) WithoutTag() TagCascadeMod {
+	return TagCascadeModFunc(func(ctx context.Context, o *TagCascadeTemplate) {
+		o.r.Tag = nil
+	})
+}

--- a/internal/db/factory/tags.bob.go
+++ b/internal/db/factory/tags.bob.go
@@ -52,6 +52,7 @@ type TagTemplate struct {
 type tagR struct {
 	Posts       []*tagRPostsR
 	TagAliases  []*tagRTagAliasesR
+	Tags        []*tagRTagsR
 	TagCategory *tagRTagCategoryR
 }
 
@@ -62,6 +63,10 @@ type tagRPostsR struct {
 type tagRTagAliasesR struct {
 	number int
 	o      *TagAliasTemplate
+}
+type tagRTagsR struct {
+	number int
+	o      *TagTemplate
 }
 type tagRTagCategoryR struct {
 	o *TagCategoryTemplate
@@ -100,6 +105,18 @@ func (t TagTemplate) setModelRels(o *models.Tag) {
 			rel = append(rel, related...)
 		}
 		o.R.TagAliases = rel
+	}
+
+	if t.r.Tags != nil {
+		rel := models.TagSlice{}
+		for _, r := range t.r.Tags {
+			related := r.o.BuildMany(r.number)
+			for _, rel := range related {
+				rel.R.Tags = append(rel.R.Tags, o)
+			}
+			rel = append(rel, related...)
+		}
+		o.R.Tags = rel
 	}
 
 	if t.r.TagCategory != nil {
@@ -251,18 +268,38 @@ func (o *TagTemplate) insertOptRels(ctx context.Context, exec bob.Executor, m *m
 		}
 	}
 
+	isTagsDone, _ := tagRelTagsCtx.Value(ctx)
+	if !isTagsDone && o.r.Tags != nil {
+		ctx = tagRelTagsCtx.WithValue(ctx, true)
+		for _, r := range o.r.Tags {
+			if r.o.alreadyPersisted {
+				m.R.Tags = append(m.R.Tags, r.o.Build())
+			} else {
+				rel2, err := r.o.CreateMany(ctx, exec, r.number)
+				if err != nil {
+					return err
+				}
+
+				err = m.AttachTags(ctx, exec, rel2...)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+
 	isTagCategoryDone, _ := tagRelTagCategoryCtx.Value(ctx)
 	if !isTagCategoryDone && o.r.TagCategory != nil {
 		ctx = tagRelTagCategoryCtx.WithValue(ctx, true)
 		if o.r.TagCategory.o.alreadyPersisted {
 			m.R.TagCategory = o.r.TagCategory.o.Build()
 		} else {
-			var rel2 *models.TagCategory
-			rel2, err = o.r.TagCategory.o.Create(ctx, exec)
+			var rel3 *models.TagCategory
+			rel3, err = o.r.TagCategory.o.Create(ctx, exec)
 			if err != nil {
 				return err
 			}
-			err = m.AttachTagCategory(ctx, exec, rel2)
+			err = m.AttachTagCategory(ctx, exec, rel3)
 			if err != nil {
 				return err
 			}
@@ -716,5 +753,53 @@ func (m tagMods) AddExistingTagAliases(existingModels ...*models.TagAlias) TagMo
 func (m tagMods) WithoutTagAliases() TagMod {
 	return TagModFunc(func(ctx context.Context, o *TagTemplate) {
 		o.r.TagAliases = nil
+	})
+}
+
+func (m tagMods) WithTags(number int, related *TagTemplate) TagMod {
+	return TagModFunc(func(ctx context.Context, o *TagTemplate) {
+		o.r.Tags = []*tagRTagsR{{
+			number: number,
+			o:      related,
+		}}
+	})
+}
+
+func (m tagMods) WithNewTags(number int, mods ...TagMod) TagMod {
+	return TagModFunc(func(ctx context.Context, o *TagTemplate) {
+		related := o.f.NewTagWithContext(ctx, mods...)
+		m.WithTags(number, related).Apply(ctx, o)
+	})
+}
+
+func (m tagMods) AddTags(number int, related *TagTemplate) TagMod {
+	return TagModFunc(func(ctx context.Context, o *TagTemplate) {
+		o.r.Tags = append(o.r.Tags, &tagRTagsR{
+			number: number,
+			o:      related,
+		})
+	})
+}
+
+func (m tagMods) AddNewTags(number int, mods ...TagMod) TagMod {
+	return TagModFunc(func(ctx context.Context, o *TagTemplate) {
+		related := o.f.NewTagWithContext(ctx, mods...)
+		m.AddTags(number, related).Apply(ctx, o)
+	})
+}
+
+func (m tagMods) AddExistingTags(existingModels ...*models.Tag) TagMod {
+	return TagModFunc(func(ctx context.Context, o *TagTemplate) {
+		for _, em := range existingModels {
+			o.r.Tags = append(o.r.Tags, &tagRTagsR{
+				o: o.f.FromExistingTag(em),
+			})
+		}
+	})
+}
+
+func (m tagMods) WithoutTags() TagMod {
+	return TagModFunc(func(ctx context.Context, o *TagTemplate) {
+		o.r.Tags = nil
 	})
 }

--- a/internal/db/migrations/data/000002_tag_cascades.down.sql
+++ b/internal/db/migrations/data/000002_tag_cascades.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS tag_cascades;

--- a/internal/db/migrations/data/000002_tag_cascades.up.sql
+++ b/internal/db/migrations/data/000002_tag_cascades.up.sql
@@ -1,0 +1,7 @@
+CREATE TABLE tag_cascades (
+    tag_id         UUID NOT NULL REFERENCES tags(id) ON DELETE CASCADE,
+    cascaded_tag_id UUID NOT NULL REFERENCES tags(id) ON DELETE CASCADE,
+    PRIMARY KEY (tag_id, cascaded_tag_id),
+    CONSTRAINT chk_no_self_cascade CHECK (tag_id != cascaded_tag_id)
+);
+CREATE INDEX idx_tag_cascades_cascaded_tag_id ON tag_cascades(cascaded_tag_id);

--- a/internal/db/models/bob_joins.bob.go
+++ b/internal/db/models/bob_joins.bob.go
@@ -35,6 +35,7 @@ type joins[Q dialect.Joinable] struct {
 	Posts         joinSet[postJoins[Q]]
 	PostsTags     joinSet[postsTagJoins[Q]]
 	TagAliases    joinSet[tagAliasJoins[Q]]
+	TagCascades   joinSet[tagCascadeJoins[Q]]
 	TagCategories joinSet[tagCategoryJoins[Q]]
 	Tags          joinSet[tagJoins[Q]]
 }
@@ -52,6 +53,7 @@ func getJoins[Q dialect.Joinable]() joins[Q] {
 		Posts:         buildJoinSet[postJoins[Q]](Posts.Columns, buildPostJoins),
 		PostsTags:     buildJoinSet[postsTagJoins[Q]](PostsTags.Columns, buildPostsTagJoins),
 		TagAliases:    buildJoinSet[tagAliasJoins[Q]](TagAliases.Columns, buildTagAliasJoins),
+		TagCascades:   buildJoinSet[tagCascadeJoins[Q]](TagCascades.Columns, buildTagCascadeJoins),
 		TagCategories: buildJoinSet[tagCategoryJoins[Q]](TagCategories.Columns, buildTagCategoryJoins),
 		Tags:          buildJoinSet[tagJoins[Q]](Tags.Columns, buildTagJoins),
 	}

--- a/internal/db/models/bob_loaders.bob.go
+++ b/internal/db/models/bob_loaders.bob.go
@@ -20,6 +20,7 @@ type preloaders struct {
 	Post        postPreloader
 	PostsTag    postsTagPreloader
 	TagAlias    tagAliasPreloader
+	TagCascade  tagCascadePreloader
 	TagCategory tagCategoryPreloader
 	Tag         tagPreloader
 }
@@ -29,6 +30,7 @@ func getPreloaders() preloaders {
 		Post:        buildPostPreloader(),
 		PostsTag:    buildPostsTagPreloader(),
 		TagAlias:    buildTagAliasPreloader(),
+		TagCascade:  buildTagCascadePreloader(),
 		TagCategory: buildTagCategoryPreloader(),
 		Tag:         buildTagPreloader(),
 	}
@@ -44,6 +46,7 @@ type thenLoaders[Q orm.Loadable] struct {
 	Post        postThenLoader[Q]
 	PostsTag    postsTagThenLoader[Q]
 	TagAlias    tagAliasThenLoader[Q]
+	TagCascade  tagCascadeThenLoader[Q]
 	TagCategory tagCategoryThenLoader[Q]
 	Tag         tagThenLoader[Q]
 }
@@ -53,6 +56,7 @@ func getThenLoaders[Q orm.Loadable]() thenLoaders[Q] {
 		Post:        buildPostThenLoader[Q](),
 		PostsTag:    buildPostsTagThenLoader[Q](),
 		TagAlias:    buildTagAliasThenLoader[Q](),
+		TagCascade:  buildTagCascadeThenLoader[Q](),
 		TagCategory: buildTagCategoryThenLoader[Q](),
 		Tag:         buildTagThenLoader[Q](),
 	}

--- a/internal/db/models/bob_types.bob_test.go
+++ b/internal/db/models/bob_types.bob_test.go
@@ -26,6 +26,9 @@ var _ bob.HookableType = &PostsTag{}
 // Make sure the type TagAlias runs hooks after queries
 var _ bob.HookableType = &TagAlias{}
 
+// Make sure the type TagCascade runs hooks after queries
+var _ bob.HookableType = &TagCascade{}
+
 // Make sure the type TagCategory runs hooks after queries
 var _ bob.HookableType = &TagCategory{}
 

--- a/internal/db/models/bob_where.bob.go
+++ b/internal/db/models/bob_where.bob.go
@@ -21,6 +21,7 @@ func Where[Q psql.Filterable]() struct {
 	Posts         postWhere[Q]
 	PostsTags     postsTagWhere[Q]
 	TagAliases    tagAliasWhere[Q]
+	TagCascades   tagCascadeWhere[Q]
 	TagCategories tagCategoryWhere[Q]
 	Tags          tagWhere[Q]
 } {
@@ -29,6 +30,7 @@ func Where[Q psql.Filterable]() struct {
 		Posts         postWhere[Q]
 		PostsTags     postsTagWhere[Q]
 		TagAliases    tagAliasWhere[Q]
+		TagCascades   tagCascadeWhere[Q]
 		TagCategories tagCategoryWhere[Q]
 		Tags          tagWhere[Q]
 	}{
@@ -36,6 +38,7 @@ func Where[Q psql.Filterable]() struct {
 		Posts:         buildPostWhere[Q](Posts.Columns),
 		PostsTags:     buildPostsTagWhere[Q](PostsTags.Columns),
 		TagAliases:    buildTagAliasWhere[Q](TagAliases.Columns),
+		TagCascades:   buildTagCascadeWhere[Q](TagCascades.Columns),
 		TagCategories: buildTagCategoryWhere[Q](TagCategories.Columns),
 		Tags:          buildTagWhere[Q](Tags.Columns),
 	}

--- a/internal/db/models/tag_cascades.bob.go
+++ b/internal/db/models/tag_cascades.bob.go
@@ -1,0 +1,786 @@
+// Code generated . DO NOT EDIT.
+// This file is meant to be re-generated in place and/or deleted at any time.
+
+package models
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/gofrs/uuid/v5"
+	"github.com/stephenafamo/bob"
+	"github.com/stephenafamo/bob/dialect/psql"
+	"github.com/stephenafamo/bob/dialect/psql/dialect"
+	"github.com/stephenafamo/bob/dialect/psql/dm"
+	"github.com/stephenafamo/bob/dialect/psql/sm"
+	"github.com/stephenafamo/bob/dialect/psql/um"
+	"github.com/stephenafamo/bob/expr"
+	"github.com/stephenafamo/bob/mods"
+	"github.com/stephenafamo/bob/orm"
+	"github.com/stephenafamo/bob/types/pgtypes"
+)
+
+// TagCascade is an object representing the database table.
+type TagCascade struct {
+	TagID         uuid.UUID `db:"tag_id,pk" `
+	CascadedTagID uuid.UUID `db:"cascaded_tag_id,pk" `
+
+	R tagCascadeR `db:"-" `
+}
+
+// TagCascadeSlice is an alias for a slice of pointers to TagCascade.
+// This should almost always be used instead of []*TagCascade.
+type TagCascadeSlice []*TagCascade
+
+// TagCascades contains methods to work with the tag_cascades table
+var TagCascades = psql.NewTablex[*TagCascade, TagCascadeSlice, *TagCascadeSetter]("", "tag_cascades", buildTagCascadeColumns("tag_cascades"))
+
+// TagCascadesQuery is a query on the tag_cascades table
+type TagCascadesQuery = *psql.ViewQuery[*TagCascade, TagCascadeSlice]
+
+// tagCascadeR is where relationships are stored.
+type tagCascadeR struct {
+	CascadedTagTag *Tag // tag_cascades.tag_cascades_cascaded_tag_id_fkey
+	Tag            *Tag // tag_cascades.tag_cascades_tag_id_fkey
+}
+
+func buildTagCascadeColumns(alias string) tagCascadeColumns {
+	return tagCascadeColumns{
+		ColumnsExpr: expr.NewColumnsExpr(
+			"tag_id", "cascaded_tag_id",
+		).WithParent("tag_cascades"),
+		tableAlias:    alias,
+		TagID:         psql.Quote(alias, "tag_id"),
+		CascadedTagID: psql.Quote(alias, "cascaded_tag_id"),
+	}
+}
+
+type tagCascadeColumns struct {
+	expr.ColumnsExpr
+	tableAlias    string
+	TagID         psql.Expression
+	CascadedTagID psql.Expression
+}
+
+func (c tagCascadeColumns) Alias() string {
+	return c.tableAlias
+}
+
+func (tagCascadeColumns) AliasedAs(alias string) tagCascadeColumns {
+	return buildTagCascadeColumns(alias)
+}
+
+// TagCascadeSetter is used for insert/upsert/update operations
+// All values are optional, and do not have to be set
+// Generated columns are not included
+type TagCascadeSetter struct {
+	TagID         *uuid.UUID `db:"tag_id,pk" `
+	CascadedTagID *uuid.UUID `db:"cascaded_tag_id,pk" `
+}
+
+func (s TagCascadeSetter) SetColumns() []string {
+	vals := make([]string, 0, 2)
+	if s.TagID != nil {
+		vals = append(vals, "tag_id")
+	}
+	if s.CascadedTagID != nil {
+		vals = append(vals, "cascaded_tag_id")
+	}
+	return vals
+}
+
+func (s TagCascadeSetter) Overwrite(t *TagCascade) {
+	if s.TagID != nil {
+		t.TagID = func() uuid.UUID {
+			if s.TagID == nil {
+				return *new(uuid.UUID)
+			}
+			return *s.TagID
+		}()
+	}
+	if s.CascadedTagID != nil {
+		t.CascadedTagID = func() uuid.UUID {
+			if s.CascadedTagID == nil {
+				return *new(uuid.UUID)
+			}
+			return *s.CascadedTagID
+		}()
+	}
+}
+
+func (s *TagCascadeSetter) Apply(q *dialect.InsertQuery) {
+	q.AppendHooks(func(ctx context.Context, exec bob.Executor) (context.Context, error) {
+		return TagCascades.BeforeInsertHooks.RunHooks(ctx, exec, s)
+	})
+
+	q.AppendValues(bob.ExpressionFunc(func(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
+		vals := make([]bob.Expression, 2)
+		if s.TagID != nil {
+			vals[0] = psql.Arg(func() uuid.UUID {
+				if s.TagID == nil {
+					return *new(uuid.UUID)
+				}
+				return *s.TagID
+			}())
+		} else {
+			vals[0] = psql.Raw("DEFAULT")
+		}
+
+		if s.CascadedTagID != nil {
+			vals[1] = psql.Arg(func() uuid.UUID {
+				if s.CascadedTagID == nil {
+					return *new(uuid.UUID)
+				}
+				return *s.CascadedTagID
+			}())
+		} else {
+			vals[1] = psql.Raw("DEFAULT")
+		}
+
+		return bob.ExpressSlice(ctx, w, d, start, vals, "", ", ", "")
+	}))
+}
+
+func (s TagCascadeSetter) UpdateMod() bob.Mod[*dialect.UpdateQuery] {
+	return um.Set(s.Expressions()...)
+}
+
+func (s TagCascadeSetter) Expressions(prefix ...string) []bob.Expression {
+	exprs := make([]bob.Expression, 0, 2)
+
+	if s.TagID != nil {
+		exprs = append(exprs, expr.Join{Sep: " = ", Exprs: []bob.Expression{
+			psql.Quote(append(prefix, "tag_id")...),
+			psql.Arg(s.TagID),
+		}})
+	}
+
+	if s.CascadedTagID != nil {
+		exprs = append(exprs, expr.Join{Sep: " = ", Exprs: []bob.Expression{
+			psql.Quote(append(prefix, "cascaded_tag_id")...),
+			psql.Arg(s.CascadedTagID),
+		}})
+	}
+
+	return exprs
+}
+
+// FindTagCascade retrieves a single record by primary key
+// If cols is empty Find will return all columns.
+func FindTagCascade(ctx context.Context, exec bob.Executor, TagIDPK uuid.UUID, CascadedTagIDPK uuid.UUID, cols ...string) (*TagCascade, error) {
+	if len(cols) == 0 {
+		return TagCascades.Query(
+			sm.Where(TagCascades.Columns.TagID.EQ(psql.Arg(TagIDPK))),
+			sm.Where(TagCascades.Columns.CascadedTagID.EQ(psql.Arg(CascadedTagIDPK))),
+		).One(ctx, exec)
+	}
+
+	return TagCascades.Query(
+		sm.Where(TagCascades.Columns.TagID.EQ(psql.Arg(TagIDPK))),
+		sm.Where(TagCascades.Columns.CascadedTagID.EQ(psql.Arg(CascadedTagIDPK))),
+		sm.Columns(TagCascades.Columns.Only(cols...)),
+	).One(ctx, exec)
+}
+
+// TagCascadeExists checks the presence of a single record by primary key
+func TagCascadeExists(ctx context.Context, exec bob.Executor, TagIDPK uuid.UUID, CascadedTagIDPK uuid.UUID) (bool, error) {
+	return TagCascades.Query(
+		sm.Where(TagCascades.Columns.TagID.EQ(psql.Arg(TagIDPK))),
+		sm.Where(TagCascades.Columns.CascadedTagID.EQ(psql.Arg(CascadedTagIDPK))),
+	).Exists(ctx, exec)
+}
+
+// AfterQueryHook is called after TagCascade is retrieved from the database
+func (o *TagCascade) AfterQueryHook(ctx context.Context, exec bob.Executor, queryType bob.QueryType) error {
+	var err error
+
+	switch queryType {
+	case bob.QueryTypeSelect:
+		ctx, err = TagCascades.AfterSelectHooks.RunHooks(ctx, exec, TagCascadeSlice{o})
+	case bob.QueryTypeInsert:
+		ctx, err = TagCascades.AfterInsertHooks.RunHooks(ctx, exec, TagCascadeSlice{o})
+	case bob.QueryTypeUpdate:
+		ctx, err = TagCascades.AfterUpdateHooks.RunHooks(ctx, exec, TagCascadeSlice{o})
+	case bob.QueryTypeDelete:
+		ctx, err = TagCascades.AfterDeleteHooks.RunHooks(ctx, exec, TagCascadeSlice{o})
+	}
+
+	return err
+}
+
+// primaryKeyVals returns the primary key values of the TagCascade
+func (o *TagCascade) primaryKeyVals() bob.Expression {
+	return psql.ArgGroup(
+		o.TagID,
+		o.CascadedTagID,
+	)
+}
+
+func (o *TagCascade) pkEQ() dialect.Expression {
+	return psql.Group(psql.Quote("tag_cascades", "tag_id"), psql.Quote("tag_cascades", "cascaded_tag_id")).EQ(bob.ExpressionFunc(func(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
+		return o.primaryKeyVals().WriteSQL(ctx, w, d, start)
+	}))
+}
+
+// Update uses an executor to update the TagCascade
+func (o *TagCascade) Update(ctx context.Context, exec bob.Executor, s *TagCascadeSetter) error {
+	v, err := TagCascades.Update(s.UpdateMod(), um.Where(o.pkEQ())).One(ctx, exec)
+	if err != nil {
+		return err
+	}
+
+	o.R = v.R
+	*o = *v
+
+	return nil
+}
+
+// Delete deletes a single TagCascade record with an executor
+func (o *TagCascade) Delete(ctx context.Context, exec bob.Executor) error {
+	_, err := TagCascades.Delete(dm.Where(o.pkEQ())).Exec(ctx, exec)
+	return err
+}
+
+// Reload refreshes the TagCascade using the executor
+func (o *TagCascade) Reload(ctx context.Context, exec bob.Executor) error {
+	o2, err := TagCascades.Query(
+		sm.Where(TagCascades.Columns.TagID.EQ(psql.Arg(o.TagID))),
+		sm.Where(TagCascades.Columns.CascadedTagID.EQ(psql.Arg(o.CascadedTagID))),
+	).One(ctx, exec)
+	if err != nil {
+		return err
+	}
+	o2.R = o.R
+	*o = *o2
+
+	return nil
+}
+
+// AfterQueryHook is called after TagCascadeSlice is retrieved from the database
+func (o TagCascadeSlice) AfterQueryHook(ctx context.Context, exec bob.Executor, queryType bob.QueryType) error {
+	var err error
+
+	switch queryType {
+	case bob.QueryTypeSelect:
+		ctx, err = TagCascades.AfterSelectHooks.RunHooks(ctx, exec, o)
+	case bob.QueryTypeInsert:
+		ctx, err = TagCascades.AfterInsertHooks.RunHooks(ctx, exec, o)
+	case bob.QueryTypeUpdate:
+		ctx, err = TagCascades.AfterUpdateHooks.RunHooks(ctx, exec, o)
+	case bob.QueryTypeDelete:
+		ctx, err = TagCascades.AfterDeleteHooks.RunHooks(ctx, exec, o)
+	}
+
+	return err
+}
+
+func (o TagCascadeSlice) pkIN() dialect.Expression {
+	if len(o) == 0 {
+		return psql.Raw("NULL")
+	}
+
+	return psql.Group(psql.Quote("tag_cascades", "tag_id"), psql.Quote("tag_cascades", "cascaded_tag_id")).In(bob.ExpressionFunc(func(ctx context.Context, w io.StringWriter, d bob.Dialect, start int) ([]any, error) {
+		pkPairs := make([]bob.Expression, len(o))
+		for i, row := range o {
+			pkPairs[i] = row.primaryKeyVals()
+		}
+		return bob.ExpressSlice(ctx, w, d, start, pkPairs, "", ", ", "")
+	}))
+}
+
+// copyMatchingRows finds models in the given slice that have the same primary key
+// then it first copies the existing relationships from the old model to the new model
+// and then replaces the old model in the slice with the new model
+func (o TagCascadeSlice) copyMatchingRows(from ...*TagCascade) {
+	for i, old := range o {
+		for _, new := range from {
+			if new.TagID != old.TagID {
+				continue
+			}
+			if new.CascadedTagID != old.CascadedTagID {
+				continue
+			}
+			new.R = old.R
+			o[i] = new
+			break
+		}
+	}
+}
+
+// UpdateMod modifies an update query with "WHERE primary_key IN (o...)"
+func (o TagCascadeSlice) UpdateMod() bob.Mod[*dialect.UpdateQuery] {
+	return bob.ModFunc[*dialect.UpdateQuery](func(q *dialect.UpdateQuery) {
+		q.AppendHooks(func(ctx context.Context, exec bob.Executor) (context.Context, error) {
+			return TagCascades.BeforeUpdateHooks.RunHooks(ctx, exec, o)
+		})
+
+		q.AppendLoader(bob.LoaderFunc(func(ctx context.Context, exec bob.Executor, retrieved any) error {
+			var err error
+			switch retrieved := retrieved.(type) {
+			case *TagCascade:
+				o.copyMatchingRows(retrieved)
+			case []*TagCascade:
+				o.copyMatchingRows(retrieved...)
+			case TagCascadeSlice:
+				o.copyMatchingRows(retrieved...)
+			default:
+				// If the retrieved value is not a TagCascade or a slice of TagCascade
+				// then run the AfterUpdateHooks on the slice
+				_, err = TagCascades.AfterUpdateHooks.RunHooks(ctx, exec, o)
+			}
+
+			return err
+		}))
+
+		q.AppendWhere(o.pkIN())
+	})
+}
+
+// DeleteMod modifies an delete query with "WHERE primary_key IN (o...)"
+func (o TagCascadeSlice) DeleteMod() bob.Mod[*dialect.DeleteQuery] {
+	return bob.ModFunc[*dialect.DeleteQuery](func(q *dialect.DeleteQuery) {
+		q.AppendHooks(func(ctx context.Context, exec bob.Executor) (context.Context, error) {
+			return TagCascades.BeforeDeleteHooks.RunHooks(ctx, exec, o)
+		})
+
+		q.AppendLoader(bob.LoaderFunc(func(ctx context.Context, exec bob.Executor, retrieved any) error {
+			var err error
+			switch retrieved := retrieved.(type) {
+			case *TagCascade:
+				o.copyMatchingRows(retrieved)
+			case []*TagCascade:
+				o.copyMatchingRows(retrieved...)
+			case TagCascadeSlice:
+				o.copyMatchingRows(retrieved...)
+			default:
+				// If the retrieved value is not a TagCascade or a slice of TagCascade
+				// then run the AfterDeleteHooks on the slice
+				_, err = TagCascades.AfterDeleteHooks.RunHooks(ctx, exec, o)
+			}
+
+			return err
+		}))
+
+		q.AppendWhere(o.pkIN())
+	})
+}
+
+func (o TagCascadeSlice) UpdateAll(ctx context.Context, exec bob.Executor, vals TagCascadeSetter) error {
+	if len(o) == 0 {
+		return nil
+	}
+
+	_, err := TagCascades.Update(vals.UpdateMod(), o.UpdateMod()).All(ctx, exec)
+	return err
+}
+
+func (o TagCascadeSlice) DeleteAll(ctx context.Context, exec bob.Executor) error {
+	if len(o) == 0 {
+		return nil
+	}
+
+	_, err := TagCascades.Delete(o.DeleteMod()).Exec(ctx, exec)
+	return err
+}
+
+func (o TagCascadeSlice) ReloadAll(ctx context.Context, exec bob.Executor) error {
+	if len(o) == 0 {
+		return nil
+	}
+
+	o2, err := TagCascades.Query(sm.Where(o.pkIN())).All(ctx, exec)
+	if err != nil {
+		return err
+	}
+
+	o.copyMatchingRows(o2...)
+
+	return nil
+}
+
+// CascadedTagTag starts a query for related objects on tags
+func (o *TagCascade) CascadedTagTag(mods ...bob.Mod[*dialect.SelectQuery]) TagsQuery {
+	return Tags.Query(append(mods,
+		sm.Where(Tags.Columns.ID.EQ(psql.Arg(o.CascadedTagID))),
+	)...)
+}
+
+func (os TagCascadeSlice) CascadedTagTag(mods ...bob.Mod[*dialect.SelectQuery]) TagsQuery {
+	pkCascadedTagID := make(pgtypes.Array[uuid.UUID], 0, len(os))
+	for _, o := range os {
+		if o == nil {
+			continue
+		}
+		pkCascadedTagID = append(pkCascadedTagID, o.CascadedTagID)
+	}
+	PKArgExpr := psql.Select(sm.Columns(
+		psql.F("unnest", psql.Cast(psql.Arg(pkCascadedTagID), "uuid[]")),
+	))
+
+	return Tags.Query(append(mods,
+		sm.Where(psql.Group(Tags.Columns.ID).OP("IN", PKArgExpr)),
+	)...)
+}
+
+// Tag starts a query for related objects on tags
+func (o *TagCascade) Tag(mods ...bob.Mod[*dialect.SelectQuery]) TagsQuery {
+	return Tags.Query(append(mods,
+		sm.Where(Tags.Columns.ID.EQ(psql.Arg(o.TagID))),
+	)...)
+}
+
+func (os TagCascadeSlice) Tag(mods ...bob.Mod[*dialect.SelectQuery]) TagsQuery {
+	pkTagID := make(pgtypes.Array[uuid.UUID], 0, len(os))
+	for _, o := range os {
+		if o == nil {
+			continue
+		}
+		pkTagID = append(pkTagID, o.TagID)
+	}
+	PKArgExpr := psql.Select(sm.Columns(
+		psql.F("unnest", psql.Cast(psql.Arg(pkTagID), "uuid[]")),
+	))
+
+	return Tags.Query(append(mods,
+		sm.Where(psql.Group(Tags.Columns.ID).OP("IN", PKArgExpr)),
+	)...)
+}
+
+func attachTagCascadeCascadedTagTag0(ctx context.Context, exec bob.Executor, count int, tagCascade0 *TagCascade, tag1 *Tag) (*TagCascade, error) {
+	setter := &TagCascadeSetter{
+		CascadedTagID: func() *uuid.UUID { return &tag1.ID }(),
+	}
+
+	err := tagCascade0.Update(ctx, exec, setter)
+	if err != nil {
+		return nil, fmt.Errorf("attachTagCascadeCascadedTagTag0: %w", err)
+	}
+
+	return tagCascade0, nil
+}
+
+func (tagCascade0 *TagCascade) InsertCascadedTagTag(ctx context.Context, exec bob.Executor, related *TagSetter) error {
+	var err error
+
+	tag1, err := Tags.Insert(related).One(ctx, exec)
+	if err != nil {
+		return fmt.Errorf("inserting related objects: %w", err)
+	}
+
+	_, err = attachTagCascadeCascadedTagTag0(ctx, exec, 1, tagCascade0, tag1)
+	if err != nil {
+		return err
+	}
+
+	tagCascade0.R.CascadedTagTag = tag1
+
+	return nil
+}
+
+func (tagCascade0 *TagCascade) AttachCascadedTagTag(ctx context.Context, exec bob.Executor, tag1 *Tag) error {
+	var err error
+
+	_, err = attachTagCascadeCascadedTagTag0(ctx, exec, 1, tagCascade0, tag1)
+	if err != nil {
+		return err
+	}
+
+	tagCascade0.R.CascadedTagTag = tag1
+
+	return nil
+}
+
+func attachTagCascadeTag0(ctx context.Context, exec bob.Executor, count int, tagCascade0 *TagCascade, tag1 *Tag) (*TagCascade, error) {
+	setter := &TagCascadeSetter{
+		TagID: func() *uuid.UUID { return &tag1.ID }(),
+	}
+
+	err := tagCascade0.Update(ctx, exec, setter)
+	if err != nil {
+		return nil, fmt.Errorf("attachTagCascadeTag0: %w", err)
+	}
+
+	return tagCascade0, nil
+}
+
+func (tagCascade0 *TagCascade) InsertTag(ctx context.Context, exec bob.Executor, related *TagSetter) error {
+	var err error
+
+	tag1, err := Tags.Insert(related).One(ctx, exec)
+	if err != nil {
+		return fmt.Errorf("inserting related objects: %w", err)
+	}
+
+	_, err = attachTagCascadeTag0(ctx, exec, 1, tagCascade0, tag1)
+	if err != nil {
+		return err
+	}
+
+	tagCascade0.R.Tag = tag1
+
+	return nil
+}
+
+func (tagCascade0 *TagCascade) AttachTag(ctx context.Context, exec bob.Executor, tag1 *Tag) error {
+	var err error
+
+	_, err = attachTagCascadeTag0(ctx, exec, 1, tagCascade0, tag1)
+	if err != nil {
+		return err
+	}
+
+	tagCascade0.R.Tag = tag1
+
+	return nil
+}
+
+type tagCascadeWhere[Q psql.Filterable] struct {
+	TagID         psql.WhereMod[Q, uuid.UUID]
+	CascadedTagID psql.WhereMod[Q, uuid.UUID]
+}
+
+func (tagCascadeWhere[Q]) AliasedAs(alias string) tagCascadeWhere[Q] {
+	return buildTagCascadeWhere[Q](buildTagCascadeColumns(alias))
+}
+
+func buildTagCascadeWhere[Q psql.Filterable](cols tagCascadeColumns) tagCascadeWhere[Q] {
+	return tagCascadeWhere[Q]{
+		TagID:         psql.Where[Q, uuid.UUID](cols.TagID),
+		CascadedTagID: psql.Where[Q, uuid.UUID](cols.CascadedTagID),
+	}
+}
+
+func (o *TagCascade) Preload(name string, retrieved any) error {
+	if o == nil {
+		return nil
+	}
+
+	switch name {
+	case "CascadedTagTag":
+		rel, ok := retrieved.(*Tag)
+		if !ok {
+			return fmt.Errorf("tagCascade cannot load %T as %q", retrieved, name)
+		}
+
+		o.R.CascadedTagTag = rel
+
+		return nil
+	case "Tag":
+		rel, ok := retrieved.(*Tag)
+		if !ok {
+			return fmt.Errorf("tagCascade cannot load %T as %q", retrieved, name)
+		}
+
+		o.R.Tag = rel
+
+		return nil
+	default:
+		return fmt.Errorf("tagCascade has no relationship %q", name)
+	}
+}
+
+type tagCascadePreloader struct {
+	CascadedTagTag func(...psql.PreloadOption) psql.Preloader
+	Tag            func(...psql.PreloadOption) psql.Preloader
+}
+
+func buildTagCascadePreloader() tagCascadePreloader {
+	return tagCascadePreloader{
+		CascadedTagTag: func(opts ...psql.PreloadOption) psql.Preloader {
+			return psql.Preload[*Tag, TagSlice](psql.PreloadRel{
+				Name: "CascadedTagTag",
+				Sides: []psql.PreloadSide{
+					{
+						From:        TagCascades,
+						To:          Tags,
+						FromColumns: []string{"cascaded_tag_id"},
+						ToColumns:   []string{"id"},
+					},
+				},
+			}, Tags.Columns.Names(), opts...)
+		},
+		Tag: func(opts ...psql.PreloadOption) psql.Preloader {
+			return psql.Preload[*Tag, TagSlice](psql.PreloadRel{
+				Name: "Tag",
+				Sides: []psql.PreloadSide{
+					{
+						From:        TagCascades,
+						To:          Tags,
+						FromColumns: []string{"tag_id"},
+						ToColumns:   []string{"id"},
+					},
+				},
+			}, Tags.Columns.Names(), opts...)
+		},
+	}
+}
+
+type tagCascadeThenLoader[Q orm.Loadable] struct {
+	CascadedTagTag func(...bob.Mod[*dialect.SelectQuery]) orm.Loader[Q]
+	Tag            func(...bob.Mod[*dialect.SelectQuery]) orm.Loader[Q]
+}
+
+func buildTagCascadeThenLoader[Q orm.Loadable]() tagCascadeThenLoader[Q] {
+	type CascadedTagTagLoadInterface interface {
+		LoadCascadedTagTag(context.Context, bob.Executor, ...bob.Mod[*dialect.SelectQuery]) error
+	}
+	type TagLoadInterface interface {
+		LoadTag(context.Context, bob.Executor, ...bob.Mod[*dialect.SelectQuery]) error
+	}
+
+	return tagCascadeThenLoader[Q]{
+		CascadedTagTag: thenLoadBuilder[Q](
+			"CascadedTagTag",
+			func(ctx context.Context, exec bob.Executor, retrieved CascadedTagTagLoadInterface, mods ...bob.Mod[*dialect.SelectQuery]) error {
+				return retrieved.LoadCascadedTagTag(ctx, exec, mods...)
+			},
+		),
+		Tag: thenLoadBuilder[Q](
+			"Tag",
+			func(ctx context.Context, exec bob.Executor, retrieved TagLoadInterface, mods ...bob.Mod[*dialect.SelectQuery]) error {
+				return retrieved.LoadTag(ctx, exec, mods...)
+			},
+		),
+	}
+}
+
+// LoadCascadedTagTag loads the tagCascade's CascadedTagTag into the .R struct
+func (o *TagCascade) LoadCascadedTagTag(ctx context.Context, exec bob.Executor, mods ...bob.Mod[*dialect.SelectQuery]) error {
+	if o == nil {
+		return nil
+	}
+
+	// Reset the relationship
+	o.R.CascadedTagTag = nil
+
+	related, err := o.CascadedTagTag(mods...).One(ctx, exec)
+	if err != nil {
+		return err
+	}
+
+	o.R.CascadedTagTag = related
+	return nil
+}
+
+// LoadCascadedTagTag loads the tagCascade's CascadedTagTag into the .R struct
+func (os TagCascadeSlice) LoadCascadedTagTag(ctx context.Context, exec bob.Executor, mods ...bob.Mod[*dialect.SelectQuery]) error {
+	if len(os) == 0 {
+		return nil
+	}
+
+	tags, err := os.CascadedTagTag(mods...).All(ctx, exec)
+	if err != nil {
+		return err
+	}
+
+	for _, o := range os {
+		if o == nil {
+			continue
+		}
+
+		for _, rel := range tags {
+
+			if !(o.CascadedTagID == rel.ID) {
+				continue
+			}
+
+			o.R.CascadedTagTag = rel
+			break
+		}
+	}
+
+	return nil
+}
+
+// LoadTag loads the tagCascade's Tag into the .R struct
+func (o *TagCascade) LoadTag(ctx context.Context, exec bob.Executor, mods ...bob.Mod[*dialect.SelectQuery]) error {
+	if o == nil {
+		return nil
+	}
+
+	// Reset the relationship
+	o.R.Tag = nil
+
+	related, err := o.Tag(mods...).One(ctx, exec)
+	if err != nil {
+		return err
+	}
+
+	o.R.Tag = related
+	return nil
+}
+
+// LoadTag loads the tagCascade's Tag into the .R struct
+func (os TagCascadeSlice) LoadTag(ctx context.Context, exec bob.Executor, mods ...bob.Mod[*dialect.SelectQuery]) error {
+	if len(os) == 0 {
+		return nil
+	}
+
+	tags, err := os.Tag(mods...).All(ctx, exec)
+	if err != nil {
+		return err
+	}
+
+	for _, o := range os {
+		if o == nil {
+			continue
+		}
+
+		for _, rel := range tags {
+
+			if !(o.TagID == rel.ID) {
+				continue
+			}
+
+			o.R.Tag = rel
+			break
+		}
+	}
+
+	return nil
+}
+
+type tagCascadeJoins[Q dialect.Joinable] struct {
+	typ            string
+	CascadedTagTag modAs[Q, tagColumns]
+	Tag            modAs[Q, tagColumns]
+}
+
+func (j tagCascadeJoins[Q]) aliasedAs(alias string) tagCascadeJoins[Q] {
+	return buildTagCascadeJoins[Q](buildTagCascadeColumns(alias), j.typ)
+}
+
+func buildTagCascadeJoins[Q dialect.Joinable](cols tagCascadeColumns, typ string) tagCascadeJoins[Q] {
+	return tagCascadeJoins[Q]{
+		typ: typ,
+		CascadedTagTag: modAs[Q, tagColumns]{
+			c: Tags.Columns,
+			f: func(to tagColumns) bob.Mod[Q] {
+				mods := make(mods.QueryMods[Q], 0, 1)
+
+				{
+					mods = append(mods, dialect.Join[Q](typ, Tags.Name().As(to.Alias())).On(
+						to.ID.EQ(cols.CascadedTagID),
+					))
+				}
+
+				return mods
+			},
+		},
+		Tag: modAs[Q, tagColumns]{
+			c: Tags.Columns,
+			f: func(to tagColumns) bob.Mod[Q] {
+				mods := make(mods.QueryMods[Q], 0, 1)
+
+				{
+					mods = append(mods, dialect.Join[Q](typ, Tags.Name().As(to.Alias())).On(
+						to.ID.EQ(cols.TagID),
+					))
+				}
+
+				return mods
+			},
+		},
+	}
+}

--- a/internal/db/models/tags.bob.go
+++ b/internal/db/models/tags.bob.go
@@ -51,6 +51,7 @@ type TagsQuery = *psql.ViewQuery[*Tag, TagSlice]
 type tagR struct {
 	Posts       PostSlice     // posts_tags.posts_tags_post_id_fkeyposts_tags.posts_tags_tag_id_fkey
 	TagAliases  TagAliasSlice // tag_aliases.tag_aliases_tag_id_fkey
+	Tags        TagSlice      // tag_cascades.tag_cascades_cascaded_tag_id_fkeytag_cascades.tag_cascades_tag_id_fkey
 	TagCategory *TagCategory  // tags.tags_tag_category_id_fkey
 }
 
@@ -581,6 +582,35 @@ func (os TagSlice) TagAliases(mods ...bob.Mod[*dialect.SelectQuery]) TagAliasesQ
 	)...)
 }
 
+// Tags starts a query for related objects on tags
+func (o *Tag) Tags(mods ...bob.Mod[*dialect.SelectQuery]) TagsQuery {
+	return Tags.Query(append(mods,
+		sm.InnerJoin(TagCascades.NameAs()).On(
+			Tags.Columns.ID.EQ(TagCascades.Columns.TagID)),
+		sm.Where(TagCascades.Columns.CascadedTagID.EQ(psql.Arg(o.ID))),
+	)...)
+}
+
+func (os TagSlice) Tags(mods ...bob.Mod[*dialect.SelectQuery]) TagsQuery {
+	pkID := make(pgtypes.Array[uuid.UUID], 0, len(os))
+	for _, o := range os {
+		if o == nil {
+			continue
+		}
+		pkID = append(pkID, o.ID)
+	}
+	PKArgExpr := psql.Select(sm.Columns(
+		psql.F("unnest", psql.Cast(psql.Arg(pkID), "uuid[]")),
+	))
+
+	return Tags.Query(append(mods,
+		sm.InnerJoin(TagCascades.NameAs()).On(
+			Tags.Columns.ID.EQ(TagCascades.Columns.TagID),
+		),
+		sm.Where(psql.Group(TagCascades.Columns.CascadedTagID).OP("IN", PKArgExpr)),
+	)...)
+}
+
 // TagCategory starts a query for related objects on tag_categories
 func (o *Tag) TagCategory(mods ...bob.Mod[*dialect.SelectQuery]) TagCategoriesQuery {
 	return TagCategories.Query(append(mods,
@@ -738,6 +768,71 @@ func (tag0 *Tag) AttachTagAliases(ctx context.Context, exec bob.Executor, relate
 	return nil
 }
 
+func attachTagTags0(ctx context.Context, exec bob.Executor, count int, tag0 *Tag, tags2 TagSlice) (TagCascadeSlice, error) {
+	setters := make([]*TagCascadeSetter, count)
+	for i := range count {
+		setters[i] = &TagCascadeSetter{
+			CascadedTagID: func() *uuid.UUID { return &tag0.ID }(),
+			TagID:         func() *uuid.UUID { return &tags2[i].ID }(),
+		}
+	}
+
+	tagCascades1, err := TagCascades.Insert(bob.ToMods(setters...)).All(ctx, exec)
+	if err != nil {
+		return nil, fmt.Errorf("attachTagTags0: %w", err)
+	}
+
+	return tagCascades1, nil
+}
+
+func (tag0 *Tag) InsertTags(ctx context.Context, exec bob.Executor, related ...*TagSetter) error {
+	if len(related) == 0 {
+		return nil
+	}
+
+	var err error
+
+	inserted, err := Tags.Insert(bob.ToMods(related...)).All(ctx, exec)
+	if err != nil {
+		return fmt.Errorf("inserting related objects: %w", err)
+	}
+	tags2 := TagSlice(inserted)
+
+	_, err = attachTagTags0(ctx, exec, len(related), tag0, tags2)
+	if err != nil {
+		return err
+	}
+
+	tag0.R.Tags = append(tag0.R.Tags, tags2...)
+
+	for _, rel := range tags2 {
+		rel.R.Tags = append(rel.R.Tags, tag0)
+	}
+	return nil
+}
+
+func (tag0 *Tag) AttachTags(ctx context.Context, exec bob.Executor, related ...*Tag) error {
+	if len(related) == 0 {
+		return nil
+	}
+
+	var err error
+	tags2 := TagSlice(related)
+
+	_, err = attachTagTags0(ctx, exec, len(related), tag0, tags2)
+	if err != nil {
+		return err
+	}
+
+	tag0.R.Tags = append(tag0.R.Tags, tags2...)
+
+	for _, rel := range related {
+		rel.R.Tags = append(rel.R.Tags, tag0)
+	}
+
+	return nil
+}
+
 func attachTagTagCategory0(ctx context.Context, exec bob.Executor, count int, tag0 *Tag, tagCategory1 *TagCategory) (*Tag, error) {
 	setter := &TagSetter{
 		TagCategoryID: func() *sql.Null[uuid.UUID] { v := sql.Null[uuid.UUID]{V: tagCategory1.ID, Valid: true}; return &v }(),
@@ -844,6 +939,20 @@ func (o *Tag) Preload(name string, retrieved any) error {
 			}
 		}
 		return nil
+	case "Tags":
+		rels, ok := retrieved.(TagSlice)
+		if !ok {
+			return fmt.Errorf("tag cannot load %T as %q", retrieved, name)
+		}
+
+		o.R.Tags = rels
+
+		for _, rel := range rels {
+			if rel != nil {
+				rel.R.Tags = TagSlice{o}
+			}
+		}
+		return nil
 	case "TagCategory":
 		rel, ok := retrieved.(*TagCategory)
 		if !ok {
@@ -886,6 +995,7 @@ func buildTagPreloader() tagPreloader {
 type tagThenLoader[Q orm.Loadable] struct {
 	Posts       func(...bob.Mod[*dialect.SelectQuery]) orm.Loader[Q]
 	TagAliases  func(...bob.Mod[*dialect.SelectQuery]) orm.Loader[Q]
+	Tags        func(...bob.Mod[*dialect.SelectQuery]) orm.Loader[Q]
 	TagCategory func(...bob.Mod[*dialect.SelectQuery]) orm.Loader[Q]
 }
 
@@ -895,6 +1005,9 @@ func buildTagThenLoader[Q orm.Loadable]() tagThenLoader[Q] {
 	}
 	type TagAliasesLoadInterface interface {
 		LoadTagAliases(context.Context, bob.Executor, ...bob.Mod[*dialect.SelectQuery]) error
+	}
+	type TagsLoadInterface interface {
+		LoadTags(context.Context, bob.Executor, ...bob.Mod[*dialect.SelectQuery]) error
 	}
 	type TagCategoryLoadInterface interface {
 		LoadTagCategory(context.Context, bob.Executor, ...bob.Mod[*dialect.SelectQuery]) error
@@ -911,6 +1024,12 @@ func buildTagThenLoader[Q orm.Loadable]() tagThenLoader[Q] {
 			"TagAliases",
 			func(ctx context.Context, exec bob.Executor, retrieved TagAliasesLoadInterface, mods ...bob.Mod[*dialect.SelectQuery]) error {
 				return retrieved.LoadTagAliases(ctx, exec, mods...)
+			},
+		),
+		Tags: thenLoadBuilder[Q](
+			"Tags",
+			func(ctx context.Context, exec bob.Executor, retrieved TagsLoadInterface, mods ...bob.Mod[*dialect.SelectQuery]) error {
+				return retrieved.LoadTags(ctx, exec, mods...)
 			},
 		),
 		TagCategory: thenLoadBuilder[Q](
@@ -1064,6 +1183,87 @@ func (os TagSlice) LoadTagAliases(ctx context.Context, exec bob.Executor, mods .
 	return nil
 }
 
+// LoadTags loads the tag's Tags into the .R struct
+func (o *Tag) LoadTags(ctx context.Context, exec bob.Executor, mods ...bob.Mod[*dialect.SelectQuery]) error {
+	if o == nil {
+		return nil
+	}
+
+	// Reset the relationship
+	o.R.Tags = nil
+
+	related, err := o.Tags(mods...).All(ctx, exec)
+	if err != nil {
+		return err
+	}
+
+	for _, rel := range related {
+		rel.R.Tags = TagSlice{o}
+	}
+
+	o.R.Tags = related
+	return nil
+}
+
+// LoadTags loads the tag's Tags into the .R struct
+func (os TagSlice) LoadTags(ctx context.Context, exec bob.Executor, mods ...bob.Mod[*dialect.SelectQuery]) error {
+	if len(os) == 0 {
+		return nil
+	}
+
+	// since we are changing the columns, we need to check if the original columns were set or add the defaults
+	sq := dialect.SelectQuery{}
+	for _, mod := range mods {
+		mod.Apply(&sq)
+	}
+
+	if len(sq.SelectList.Columns) == 0 {
+		mods = append(mods, sm.Columns(Tags.Columns))
+	}
+
+	q := os.Tags(append(
+		mods,
+		sm.Columns(TagCascades.Columns.CascadedTagID.As("related_tags.ID")),
+	)...)
+
+	IDSlice := []uuid.UUID{}
+
+	mapper := scan.Mod(scan.StructMapper[*Tag](), func(ctx context.Context, cols []string) (scan.BeforeFunc, func(any, any) error) {
+		return func(row *scan.Row) (any, error) {
+				IDSlice = append(IDSlice, *new(uuid.UUID))
+				row.ScheduleScanByName("related_tags.ID", &IDSlice[len(IDSlice)-1])
+
+				return nil, nil
+			},
+			func(any, any) error {
+				return nil
+			}
+	})
+
+	tags, err := bob.Allx[bob.SliceTransformer[*Tag, TagSlice]](ctx, exec, q, mapper)
+	if err != nil {
+		return err
+	}
+
+	for _, o := range os {
+		o.R.Tags = nil
+	}
+
+	for _, o := range os {
+		for i, rel := range tags {
+			if !(o.ID == IDSlice[i]) {
+				continue
+			}
+
+			rel.R.Tags = append(rel.R.Tags, o)
+
+			o.R.Tags = append(o.R.Tags, rel)
+		}
+	}
+
+	return nil
+}
+
 // LoadTagCategory loads the tag's TagCategory into the .R struct
 func (o *Tag) LoadTagCategory(ctx context.Context, exec bob.Executor, mods ...bob.Mod[*dialect.SelectQuery]) error {
 	if o == nil {
@@ -1123,6 +1323,7 @@ type tagJoins[Q dialect.Joinable] struct {
 	typ         string
 	Posts       modAs[Q, postColumns]
 	TagAliases  modAs[Q, tagAliasColumns]
+	Tags        modAs[Q, tagColumns]
 	TagCategory modAs[Q, tagCategoryColumns]
 }
 
@@ -1163,6 +1364,28 @@ func buildTagJoins[Q dialect.Joinable](cols tagColumns, typ string) tagJoins[Q] 
 				{
 					mods = append(mods, dialect.Join[Q](typ, TagAliases.Name().As(to.Alias())).On(
 						to.TagID.EQ(cols.ID),
+					))
+				}
+
+				return mods
+			},
+		},
+		Tags: modAs[Q, tagColumns]{
+			c: Tags.Columns,
+			f: func(to tagColumns) bob.Mod[Q] {
+				random := strconv.FormatInt(randInt(), 10)
+				mods := make(mods.QueryMods[Q], 0, 2)
+
+				{
+					to := TagCascades.Columns.AliasedAs(TagCascades.Columns.Alias() + random)
+					mods = append(mods, dialect.Join[Q](typ, TagCascades.Name().As(to.Alias())).On(
+						to.CascadedTagID.EQ(cols.ID),
+					))
+				}
+				{
+					cols := TagCascades.Columns.AliasedAs(TagCascades.Columns.Alias() + random)
+					mods = append(mods, dialect.Join[Q](typ, Tags.Name().As(to.Alias())).On(
+						to.ID.EQ(cols.TagID),
 					))
 				}
 

--- a/internal/db/schema/tag_cascades.bob.go
+++ b/internal/db/schema/tag_cascades.bob.go
@@ -1,0 +1,164 @@
+// Code generated . DO NOT EDIT.
+// This file is meant to be re-generated in place and/or deleted at any time.
+
+package schema
+
+import "github.com/aarondl/opt/null"
+
+var TagCascades = Table[
+	tagCascadeColumns,
+	tagCascadeIndexes,
+	tagCascadeForeignKeys,
+	tagCascadeUniques,
+	tagCascadeChecks,
+]{
+	Schema: "",
+	Name:   "tag_cascades",
+	Columns: tagCascadeColumns{
+		TagID: column{
+			Name:      "tag_id",
+			DBType:    "uuid",
+			Default:   "",
+			Comment:   "",
+			Nullable:  false,
+			Generated: false,
+			AutoIncr:  false,
+		},
+		CascadedTagID: column{
+			Name:      "cascaded_tag_id",
+			DBType:    "uuid",
+			Default:   "",
+			Comment:   "",
+			Nullable:  false,
+			Generated: false,
+			AutoIncr:  false,
+		},
+	},
+	Indexes: tagCascadeIndexes{
+		TagCascadesPkey: index{
+			Type: "btree",
+			Name: "tag_cascades_pkey",
+			Columns: []indexColumn{
+				{
+					Name:         "tag_id",
+					Desc:         null.FromCond(false, true),
+					IsExpression: false,
+				},
+				{
+					Name:         "cascaded_tag_id",
+					Desc:         null.FromCond(false, true),
+					IsExpression: false,
+				},
+			},
+			Unique:        true,
+			Comment:       "",
+			NullsFirst:    []bool{false, false},
+			NullsDistinct: false,
+			Where:         "",
+			Include:       []string{},
+		},
+		IdxTagCascadesCascadedTagID: index{
+			Type: "btree",
+			Name: "idx_tag_cascades_cascaded_tag_id",
+			Columns: []indexColumn{
+				{
+					Name:         "cascaded_tag_id",
+					Desc:         null.FromCond(false, true),
+					IsExpression: false,
+				},
+			},
+			Unique:        false,
+			Comment:       "",
+			NullsFirst:    []bool{false},
+			NullsDistinct: false,
+			Where:         "",
+			Include:       []string{},
+		},
+	},
+	PrimaryKey: &constraint{
+		Name:    "tag_cascades_pkey",
+		Columns: []string{"tag_id", "cascaded_tag_id"},
+		Comment: "",
+	},
+	ForeignKeys: tagCascadeForeignKeys{
+		TagCascadesTagCascadesCascadedTagIDFkey: foreignKey{
+			constraint: constraint{
+				Name:    "tag_cascades.tag_cascades_cascaded_tag_id_fkey",
+				Columns: []string{"cascaded_tag_id"},
+				Comment: "",
+			},
+			ForeignTable:   "tags",
+			ForeignColumns: []string{"id"},
+		},
+		TagCascadesTagCascadesTagIDFkey: foreignKey{
+			constraint: constraint{
+				Name:    "tag_cascades.tag_cascades_tag_id_fkey",
+				Columns: []string{"tag_id"},
+				Comment: "",
+			},
+			ForeignTable:   "tags",
+			ForeignColumns: []string{"id"},
+		},
+	},
+
+	Checks: tagCascadeChecks{
+		CHKNoSelfCascade: check{
+			constraint: constraint{
+				Name:    "chk_no_self_cascade",
+				Columns: []string{"tag_id", "cascaded_tag_id"},
+				Comment: "",
+			},
+			Expression: "(tag_id <> cascaded_tag_id)",
+		},
+	},
+	Comment: "",
+}
+
+type tagCascadeColumns struct {
+	TagID         column
+	CascadedTagID column
+}
+
+func (c tagCascadeColumns) AsSlice() []column {
+	return []column{
+		c.TagID, c.CascadedTagID,
+	}
+}
+
+type tagCascadeIndexes struct {
+	TagCascadesPkey             index
+	IdxTagCascadesCascadedTagID index
+}
+
+func (i tagCascadeIndexes) AsSlice() []index {
+	return []index{
+		i.TagCascadesPkey, i.IdxTagCascadesCascadedTagID,
+	}
+}
+
+type tagCascadeForeignKeys struct {
+	TagCascadesTagCascadesCascadedTagIDFkey foreignKey
+	TagCascadesTagCascadesTagIDFkey         foreignKey
+}
+
+func (f tagCascadeForeignKeys) AsSlice() []foreignKey {
+	return []foreignKey{
+		f.TagCascadesTagCascadesCascadedTagIDFkey, f.TagCascadesTagCascadesTagIDFkey,
+	}
+}
+
+type tagCascadeUniques struct{}
+
+func (u tagCascadeUniques) AsSlice() []constraint {
+	return []constraint{}
+}
+
+type tagCascadeChecks struct {
+	CHKNoSelfCascade check
+}
+
+func (c tagCascadeChecks) AsSlice() []check {
+	return []check{
+		c.CHKNoSelfCascade,
+	}
+}

--- a/internal/db/store/notes.go
+++ b/internal/db/store/notes.go
@@ -50,13 +50,24 @@ func (s *PostgresSQLStore) CreateNote(ctx context.Context, title, content string
 }
 
 func (s *PostgresSQLStore) UpdateNote(ctx context.Context, id uuid.UUID, title, content string) (*models.Note, error) {
-	model, err := s.GetNote(ctx, id)
+	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	model, err := models.Notes.Query(
+		sm.Where(models.Notes.Columns.ID.EQ(psql.Arg(id))),
+	).One(ctx, tx)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
 		return nil, err
 	}
 
 	now := new(time.Now().UTC())
-	err = model.Update(ctx, s.db, &models.NoteSetter{
+	err = model.Update(ctx, tx, &models.NoteSetter{
 		Title:     &title,
 		Content:   &content,
 		UpdatedAt: now,
@@ -67,17 +78,36 @@ func (s *PostgresSQLStore) UpdateNote(ctx context.Context, id uuid.UUID, title, 
 	model.Title = title
 	model.Content = content
 	model.UpdatedAt = *now
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, err
+	}
 	return model, nil
 }
 
 func (s *PostgresSQLStore) DeleteNote(ctx context.Context, id uuid.UUID) error {
-	_, err := s.GetNote(ctx, id)
+	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	_, err = models.Notes.Query(
+		sm.Where(models.Notes.Columns.ID.EQ(psql.Arg(id))),
+	).One(ctx, tx)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrNotFound
+		}
 		return err
 	}
 
 	_, err = models.Notes.Delete(
 		dm.Where(models.Notes.Columns.ID.EQ(psql.Arg(id))),
-	).Exec(ctx, s.db)
-	return err
+	).Exec(ctx, tx)
+	if err != nil {
+		return err
+	}
+
+	return tx.Commit(ctx)
 }

--- a/internal/db/store/posts.go
+++ b/internal/db/store/posts.go
@@ -18,15 +18,61 @@ import (
 )
 
 func (s *PostgresSQLStore) ListPosts(ctx context.Context, params ListPostsParams) (models.PostSlice, bool, error) {
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return nil, false, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
 	mods := []bob.Mod[*dialect.SelectQuery]{}
 
-	// Apply tag inclusion filters
+	// Apply tag inclusion filters (direct tags + cascading tags)
 	for _, tagName := range params.Query.IncludedTags {
-		resolved, err := s.ResolveAlias(ctx, tagName)
+		resolved, err := s.resolveAliasWithExec(ctx, tx, tagName)
 		if err != nil {
 			return nil, false, err
 		}
-		mods = append(mods, sm.Where(psql.F("EXISTS",
+		mods = append(mods, sm.Where(psql.Or(
+			// Direct tag match
+			psql.F("EXISTS",
+				psql.Select(
+					sm.Columns(psql.S("1")),
+					sm.From("posts_tags"),
+					sm.InnerJoin("tags").OnEQ(models.PostsTags.Columns.TagID, models.Tags.Columns.ID),
+					sm.Where(psql.And(
+						models.PostsTags.Columns.PostID.EQ(models.Posts.Columns.ID),
+						models.Tags.Columns.Name.EQ(psql.Arg(resolved)),
+					)),
+				),
+			),
+			// Cascade match: post has a tag that cascades to the searched tag
+			psql.F("EXISTS",
+				psql.Select(
+					sm.Columns(psql.S("1")),
+					sm.From("posts_tags"),
+					sm.InnerJoin("tag_cascades").On(
+						models.PostsTags.Columns.TagID.EQ(psql.Raw("tag_cascades.tag_id")),
+					),
+					sm.InnerJoin("tags").On(
+						psql.Raw("tag_cascades.cascaded_tag_id").EQ(models.Tags.Columns.ID),
+					),
+					sm.Where(psql.And(
+						models.PostsTags.Columns.PostID.EQ(models.Posts.Columns.ID),
+						models.Tags.Columns.Name.EQ(psql.Arg(resolved)),
+					)),
+				),
+			),
+		)))
+	}
+
+	// Apply tag exclusion filters (direct tags + cascading tags)
+	for _, tagName := range params.Query.ExcludedTags {
+		resolved, err := s.resolveAliasWithExec(ctx, tx, tagName)
+		if err != nil {
+			return nil, false, err
+		}
+		// Exclude posts with direct tag match
+		mods = append(mods, sm.Where(psql.Not(psql.F("EXISTS",
 			psql.Select(
 				sm.Columns(psql.S("1")),
 				sm.From("posts_tags"),
@@ -36,20 +82,18 @@ func (s *PostgresSQLStore) ListPosts(ctx context.Context, params ListPostsParams
 					models.Tags.Columns.Name.EQ(psql.Arg(resolved)),
 				)),
 			),
-		)))
-	}
-
-	// Apply tag exclusion filters
-	for _, tagName := range params.Query.ExcludedTags {
-		resolved, err := s.ResolveAlias(ctx, tagName)
-		if err != nil {
-			return nil, false, err
-		}
+		))))
+		// Exclude posts with cascade match
 		mods = append(mods, sm.Where(psql.Not(psql.F("EXISTS",
 			psql.Select(
 				sm.Columns(psql.S("1")),
 				sm.From("posts_tags"),
-				sm.InnerJoin("tags").OnEQ(models.PostsTags.Columns.TagID, models.Tags.Columns.ID),
+				sm.InnerJoin("tag_cascades").On(
+					models.PostsTags.Columns.TagID.EQ(psql.Raw("tag_cascades.tag_id")),
+				),
+				sm.InnerJoin("tags").On(
+					psql.Raw("tag_cascades.cascaded_tag_id").EQ(models.Tags.Columns.ID),
+				),
 				sm.Where(psql.And(
 					models.PostsTags.Columns.PostID.EQ(models.Posts.Columns.ID),
 					models.Tags.Columns.Name.EQ(psql.Arg(resolved)),
@@ -108,12 +152,12 @@ func (s *PostgresSQLStore) ListPosts(ctx context.Context, params ListPostsParams
 			sm.Offset(int64(params.RandomOffset)),
 		)
 
-		posts, err := models.Posts.Query(mods...).All(ctx, s.db)
+		posts, err := models.Posts.Query(mods...).All(ctx, tx)
 		if err != nil {
 			return nil, false, err
 		}
 
-		if err := posts.LoadTags(ctx, s.db); err != nil {
+		if err := posts.LoadTags(ctx, tx); err != nil {
 			return nil, false, err
 		}
 
@@ -146,12 +190,12 @@ func (s *PostgresSQLStore) ListPosts(ctx context.Context, params ListPostsParams
 
 	mods = append(mods, sm.Limit(int64(params.Limit+1)))
 
-	posts, err := models.Posts.Query(mods...).All(ctx, s.db)
+	posts, err := models.Posts.Query(mods...).All(ctx, tx)
 	if err != nil {
 		return nil, false, err
 	}
 
-	if err := posts.LoadTags(ctx, s.db); err != nil {
+	if err := posts.LoadTags(ctx, tx); err != nil {
 		return nil, false, err
 	}
 
@@ -163,9 +207,15 @@ func (s *PostgresSQLStore) ListPosts(ctx context.Context, params ListPostsParams
 }
 
 func (s *PostgresSQLStore) GetPost(ctx context.Context, id uuid.UUID) (*models.Post, error) {
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
 	model, err := models.Posts.Query(
 		sm.Where(models.Posts.Columns.ID.EQ(psql.Arg(id))),
-	).One(ctx, s.db)
+	).One(ctx, tx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, ErrNotFound
@@ -173,7 +223,7 @@ func (s *PostgresSQLStore) GetPost(ctx context.Context, id uuid.UUID) (*models.P
 		return nil, err
 	}
 
-	if err := model.LoadTags(ctx, s.db); err != nil {
+	if err := model.LoadTags(ctx, tx); err != nil {
 		return nil, err
 	}
 
@@ -185,21 +235,21 @@ func (s *PostgresSQLStore) CreatePost(ctx context.Context, setter *models.PostSe
 }
 
 func (s *PostgresSQLStore) UpdatePost(ctx context.Context, id uuid.UUID, note string, tagNames []string, now time.Time) (*models.Post, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
 	existingPost, err := models.Posts.Query(
 		sm.Where(models.Posts.Columns.ID.EQ(psql.Arg(id))),
-	).One(ctx, s.db)
+	).One(ctx, tx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, ErrNotFound
 		}
 		return nil, err
 	}
-
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = tx.Rollback(ctx) }()
 
 	nowPtr := &now
 	err = existingPost.Update(ctx, tx, &models.PostSetter{
@@ -253,9 +303,15 @@ func (s *PostgresSQLStore) UpdatePost(ctx context.Context, id uuid.UUID, note st
 }
 
 func (s *PostgresSQLStore) UpdatePostContent(ctx context.Context, id uuid.UUID, setter *models.PostSetter) (*models.Post, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
 	existingPost, err := models.Posts.Query(
 		sm.Where(models.Posts.Columns.ID.EQ(psql.Arg(id))),
-	).One(ctx, s.db)
+	).One(ctx, tx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, ErrNotFound
@@ -263,12 +319,16 @@ func (s *PostgresSQLStore) UpdatePostContent(ctx context.Context, id uuid.UUID, 
 		return nil, err
 	}
 
-	err = existingPost.Update(ctx, s.db, setter)
+	err = existingPost.Update(ctx, tx, setter)
 	if err != nil {
 		return nil, err
 	}
 
-	if err = existingPost.LoadTags(ctx, s.db); err != nil {
+	if err = existingPost.LoadTags(ctx, tx); err != nil {
+		return nil, err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
 		return nil, err
 	}
 
@@ -276,9 +336,15 @@ func (s *PostgresSQLStore) UpdatePostContent(ctx context.Context, id uuid.UUID, 
 }
 
 func (s *PostgresSQLStore) UpdatePostThumbnail(ctx context.Context, id uuid.UUID, thumbnailURL string, now time.Time) (*models.Post, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
 	existingPost, err := models.Posts.Query(
 		sm.Where(models.Posts.Columns.ID.EQ(psql.Arg(id))),
-	).One(ctx, s.db)
+	).One(ctx, tx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, ErrNotFound
@@ -287,7 +353,7 @@ func (s *PostgresSQLStore) UpdatePostThumbnail(ctx context.Context, id uuid.UUID
 	}
 
 	nowPtr := &now
-	err = existingPost.Update(ctx, s.db, &models.PostSetter{
+	err = existingPost.Update(ctx, tx, &models.PostSetter{
 		ThumbnailURL: &thumbnailURL,
 		UpdatedAt:    nowPtr,
 	})
@@ -295,7 +361,11 @@ func (s *PostgresSQLStore) UpdatePostThumbnail(ctx context.Context, id uuid.UUID
 		return nil, err
 	}
 
-	if err := existingPost.LoadTags(ctx, s.db); err != nil {
+	if err := existingPost.LoadTags(ctx, tx); err != nil {
+		return nil, err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
 		return nil, err
 	}
 
@@ -303,9 +373,15 @@ func (s *PostgresSQLStore) UpdatePostThumbnail(ctx context.Context, id uuid.UUID
 }
 
 func (s *PostgresSQLStore) DeletePost(ctx context.Context, id uuid.UUID) (*models.Post, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
 	post, err := models.Posts.Query(
 		sm.Where(models.Posts.Columns.ID.EQ(psql.Arg(id))),
-	).One(ctx, s.db)
+	).One(ctx, tx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, ErrNotFound
@@ -315,8 +391,12 @@ func (s *PostgresSQLStore) DeletePost(ctx context.Context, id uuid.UUID) (*model
 
 	_, err = models.Posts.Delete(
 		dm.Where(models.Posts.Columns.ID.EQ(psql.Arg(id))),
-	).Exec(ctx, s.db)
+	).Exec(ctx, tx)
 	if err != nil {
+		return nil, err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
 		return nil, err
 	}
 
@@ -337,6 +417,12 @@ func (s *PostgresSQLStore) FindPostBySha256(ctx context.Context, hash string) (*
 }
 
 func (s *PostgresSQLStore) FindSimilarPosts(ctx context.Context, excludeID uuid.UUID, pHash int64, limit int) (models.PostSlice, error) {
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
 	phashHamming := dialect.NewFunction("bit_count",
 		psql.Cast(psql.Group(models.Posts.Columns.Phash.OP("#", psql.Arg(pHash))), "bit(64)"),
 	)
@@ -351,12 +437,12 @@ func (s *PostgresSQLStore) FindSimilarPosts(ctx context.Context, excludeID uuid.
 		mods = append(mods, sm.Where(models.Posts.Columns.ID.NE(psql.Arg(excludeID))))
 	}
 
-	posts, err := models.Posts.Query(mods...).All(ctx, s.db)
+	posts, err := models.Posts.Query(mods...).All(ctx, tx)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := posts.LoadTags(ctx, s.db); err != nil {
+	if err := posts.LoadTags(ctx, tx); err != nil {
 		return nil, err
 	}
 

--- a/internal/db/store/store.go
+++ b/internal/db/store/store.go
@@ -63,6 +63,7 @@ type TagStore interface {
 	DeleteTag(ctx context.Context, name string) error
 	GetTagPostCounts(ctx context.Context, ids []uuid.UUID) (map[uuid.UUID]int, error)
 	GetTagAliases(ctx context.Context, ids ...uuid.UUID) (map[uuid.UUID][]string, error)
+	GetTagCascades(ctx context.Context, ids ...uuid.UUID) (map[uuid.UUID][]string, error)
 	ResolveAlias(ctx context.Context, name string) (string, error)
 	ConvertTagToAlias(ctx context.Context, sourceName, targetName string) (*ConvertTagToAliasResult, error)
 }
@@ -73,6 +74,7 @@ type TagInput struct {
 	Description   string
 	Category      *string
 	Aliases       []string
+	CascadingTags []string
 	TagCategoryID sql.Null[uuid.UUID]
 }
 
@@ -93,6 +95,7 @@ type PostStore interface {
 	DeletePost(ctx context.Context, id uuid.UUID) (*models.Post, error)
 	FindPostBySha256(ctx context.Context, hash string) (*models.Post, error)
 	FindSimilarPosts(ctx context.Context, excludeID uuid.UUID, pHash int64, limit int) (models.PostSlice, error)
+	GetPostCascadingTags(ctx context.Context, postID uuid.UUID) ([]string, error)
 }
 
 // ListPostsParams holds parameters for listing posts.

--- a/internal/db/store/tag_categories.go
+++ b/internal/db/store/tag_categories.go
@@ -54,16 +54,22 @@ func (s *PostgresSQLStore) GetTagCategory(ctx context.Context, name string) (*mo
 }
 
 func (s *PostgresSQLStore) UpsertTagCategory(ctx context.Context, urlName string, input TagCategoryInput, now time.Time) (*models.TagCategory, bool, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, false, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
 	existing, err := models.TagCategories.Query(
 		sm.Where(models.TagCategories.Columns.Name.EQ(psql.Arg(urlName))),
-	).One(ctx, s.db)
+	).One(ctx, tx)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return nil, false, err
 	}
 
 	nowPtr := &now
 	if existing != nil {
-		err = existing.Update(ctx, s.db, &models.TagCategorySetter{
+		err = existing.Update(ctx, tx, &models.TagCategorySetter{
 			Name:        &input.Name,
 			Description: &input.Description,
 			Color:       &input.Color,
@@ -76,6 +82,10 @@ func (s *PostgresSQLStore) UpsertTagCategory(ctx context.Context, urlName string
 		existing.Description = input.Description
 		existing.Color = input.Color
 		existing.UpdatedAt = now
+
+		if err := tx.Commit(ctx); err != nil {
+			return nil, false, err
+		}
 		return existing, false, nil
 	}
 
@@ -87,8 +97,12 @@ func (s *PostgresSQLStore) UpsertTagCategory(ctx context.Context, urlName string
 			CreatedAt:   nowPtr,
 			UpdatedAt:   nowPtr,
 		},
-	).One(ctx, s.db)
+	).One(ctx, tx)
 	if err != nil {
+		return nil, false, err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
 		return nil, false, err
 	}
 	return inserted, true, nil

--- a/internal/db/store/tags.go
+++ b/internal/db/store/tags.go
@@ -19,6 +19,12 @@ import (
 )
 
 func (s *PostgresSQLStore) ListTags(ctx context.Context, cursor *string, limit int) (models.TagSlice, bool, error) {
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return nil, false, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
 	mods := []bob.Mod[*dialect.SelectQuery]{
 		sm.OrderBy(models.Tags.Columns.Name).Asc(),
 	}
@@ -29,12 +35,12 @@ func (s *PostgresSQLStore) ListTags(ctx context.Context, cursor *string, limit i
 
 	mods = append(mods, sm.Limit(int64(limit+1)))
 
-	tags, err := models.Tags.Query(mods...).All(ctx, s.db)
+	tags, err := models.Tags.Query(mods...).All(ctx, tx)
 	if err != nil {
 		return nil, false, err
 	}
 
-	if err := tags.LoadTagCategory(ctx, s.db); err != nil {
+	if err := tags.LoadTagCategory(ctx, tx); err != nil {
 		return nil, false, err
 	}
 
@@ -46,9 +52,15 @@ func (s *PostgresSQLStore) ListTags(ctx context.Context, cursor *string, limit i
 }
 
 func (s *PostgresSQLStore) GetTag(ctx context.Context, name string) (*models.Tag, error) {
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
 	model, err := models.Tags.Query(
 		sm.Where(models.Tags.Columns.Name.EQ(psql.Arg(name))),
-	).One(ctx, s.db)
+	).One(ctx, tx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, ErrNotFound
@@ -57,7 +69,7 @@ func (s *PostgresSQLStore) GetTag(ctx context.Context, name string) (*models.Tag
 	}
 
 	if model.TagCategoryID.Valid {
-		if err := model.LoadTagCategory(ctx, s.db); err != nil {
+		if err := model.LoadTagCategory(ctx, tx); err != nil {
 			return nil, err
 		}
 	}
@@ -116,6 +128,10 @@ func (s *PostgresSQLStore) UpsertTag(ctx context.Context, urlName string, input 
 		return nil, false, err
 	}
 
+	if err := s.setTagCascades(ctx, tx, resultModel.ID, input.CascadingTags); err != nil {
+		return nil, false, err
+	}
+
 	if err := tx.Commit(ctx); err != nil {
 		return nil, false, err
 	}
@@ -157,8 +173,16 @@ func (s *PostgresSQLStore) GetTagPostCounts(ctx context.Context, tagIDs []uuid.U
 		args[i] = id
 	}
 
+	// Count direct posts + posts that cascade to each tag
 	rows, err := s.db.QueryContext(ctx,
-		"SELECT tag_id, COUNT(*) FROM posts_tags WHERE tag_id IN ("+placeholders.String()+") GROUP BY tag_id",
+		`SELECT tag_id, COUNT(DISTINCT post_id) FROM (
+			SELECT tag_id, post_id FROM posts_tags WHERE tag_id IN (`+placeholders.String()+`)
+			UNION ALL
+			SELECT tc.cascaded_tag_id AS tag_id, pt.post_id
+			FROM tag_cascades tc
+			JOIN posts_tags pt ON pt.tag_id = tc.tag_id
+			WHERE tc.cascaded_tag_id IN (`+placeholders.String()+`)
+		) combined GROUP BY tag_id`,
 		args...,
 	)
 	if err != nil {
@@ -276,6 +300,117 @@ func (s *PostgresSQLStore) setTagAliases(ctx context.Context, exec bob.Executor,
 		}
 	}
 	return nil
+}
+
+func (s *PostgresSQLStore) GetTagCascades(ctx context.Context, ids ...uuid.UUID) (map[uuid.UUID][]string, error) {
+	if len(ids) == 0 {
+		return map[uuid.UUID][]string{}, nil
+	}
+
+	args := make([]any, len(ids))
+	var placeholders strings.Builder
+	for i, id := range ids {
+		if i > 0 {
+			placeholders.WriteString(", ")
+		}
+		placeholders.WriteString("$" + strconv.Itoa(i+1))
+		args[i] = id
+	}
+
+	rows, err := s.db.QueryContext(ctx,
+		"SELECT tc.tag_id, t.name FROM tag_cascades tc JOIN tags t ON tc.cascaded_tag_id = t.id WHERE tc.tag_id IN ("+placeholders.String()+") ORDER BY t.name",
+		args...,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	result := make(map[uuid.UUID][]string)
+	for rows.Next() {
+		var tagID uuid.UUID
+		var name string
+		if err := rows.Scan(&tagID, &name); err != nil {
+			return nil, err
+		}
+		result[tagID] = append(result[tagID], name)
+	}
+	return result, rows.Err()
+}
+
+// setTagCascades replaces all cascades for a tag with the given list.
+// Each cascade target must be an existing tag (or alias that resolves to one) and must not be the tag itself.
+func (s *PostgresSQLStore) setTagCascades(ctx context.Context, exec bob.Executor, tagID uuid.UUID, cascades []string) error {
+	_, err := models.TagCascades.Delete(
+		dm.Where(models.TagCascades.Columns.TagID.EQ(psql.Arg(tagID))),
+	).Exec(ctx, exec)
+	if err != nil {
+		return err
+	}
+	for _, name := range cascades {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+
+		// Resolve alias to canonical tag name
+		resolved, err := s.resolveAliasWithExec(ctx, exec, name)
+		if err != nil {
+			return err
+		}
+
+		// Look up the target tag
+		target, err := models.Tags.Query(
+			sm.Where(models.Tags.Columns.Name.EQ(psql.Arg(resolved))),
+		).One(ctx, exec)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return fmt.Errorf("cascade target tag %q not found", name)
+			}
+			return err
+		}
+
+		// Prevent self-cascade
+		if target.ID == tagID {
+			continue
+		}
+
+		_, err = models.TagCascades.Insert(&models.TagCascadeSetter{
+			TagID:         &tagID,
+			CascadedTagID: &target.ID,
+		}).Exec(ctx, exec)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *PostgresSQLStore) GetPostCascadingTags(ctx context.Context, postID uuid.UUID) ([]string, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT DISTINCT t2.name
+		 FROM posts_tags pt
+		 JOIN tag_cascades tc ON pt.tag_id = tc.tag_id
+		 JOIN tags t2 ON tc.cascaded_tag_id = t2.id
+		 WHERE pt.post_id = $1
+		   AND t2.id NOT IN (SELECT pt2.tag_id FROM posts_tags pt2 WHERE pt2.post_id = $1)
+		 ORDER BY t2.name`,
+		postID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var result []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		result = append(result, name)
+	}
+	return result, rows.Err()
 }
 
 func (s *PostgresSQLStore) ConvertTagToAlias(ctx context.Context, sourceName, targetName string) (*ConvertTagToAliasResult, error) {

--- a/pkg/types/gen.go
+++ b/pkg/types/gen.go
@@ -26,26 +26,28 @@ type Note struct {
 
 // Post defines model for Post.
 type Post struct {
-	ContentUrl   URL       `json:"contentUrl"`
-	CreatedAt    Timestamp `json:"createdAt"`
-	HasAudio     bool      `json:"hasAudio"`
-	ID           ID        `json:"id"`
-	MimeType     string    `json:"mimeType"`
-	Note         string    `json:"note"`
-	Tags         []TagName `json:"tags"`
-	ThumbnailUrl URL       `json:"thumbnailUrl"`
-	UpdatedAt    Timestamp `json:"updatedAt"`
+	CascadingTags *[]TagName `json:"cascadingTags,omitempty"`
+	ContentUrl    URL        `json:"contentUrl"`
+	CreatedAt     Timestamp  `json:"createdAt"`
+	HasAudio      bool       `json:"hasAudio"`
+	ID            ID         `json:"id"`
+	MimeType      string     `json:"mimeType"`
+	Note          string     `json:"note"`
+	Tags          []TagName  `json:"tags"`
+	ThumbnailUrl  URL        `json:"thumbnailUrl"`
+	UpdatedAt     Timestamp  `json:"updatedAt"`
 }
 
 // Tag defines model for Tag.
 type Tag struct {
-	Aliases     *[]string        `json:"aliases,omitempty"`
-	Category    *TagCategoryName `json:"category,omitempty"`
-	CreatedAt   Timestamp        `json:"createdAt"`
-	Description string           `json:"description"`
-	Name        TagName          `json:"name"`
-	PostCount   *int             `json:"postCount,omitempty"`
-	UpdatedAt   Timestamp        `json:"updatedAt"`
+	Aliases       *[]string        `json:"aliases,omitempty"`
+	CascadingTags *[]TagName       `json:"cascadingTags,omitempty"`
+	Category      *TagCategoryName `json:"category,omitempty"`
+	CreatedAt     Timestamp        `json:"createdAt"`
+	Description   string           `json:"description"`
+	Name          TagName          `json:"name"`
+	PostCount     *int             `json:"postCount,omitempty"`
+	UpdatedAt     Timestamp        `json:"updatedAt"`
 }
 
 // TagCategory defines model for TagCategory.


### PR DESCRIPTION
## Summary

- **Cascading tags**: Tags can declare cascade relationships to other tags. Posts tagged with a cascading tag automatically appear in searches for related tags (e.g., "corvette" cascades to "chevrolet" and "car"). Cascading is non-transitive by design.
- **Tag inclusion/exclusion**: Search filters account for cascade relationships — including a tag matches cascaded posts, excluding a tag also excludes cascaded posts.
- **Post counts**: Tag post counts include indirect associations through cascading.
- **UI**: Cascading tags appear on post pages with a transparent fill style, distinguishing them from direct tags. Tag edit page supports managing cascade relationships.
- **Transaction safety**: All multi-query store methods now use proper database transactions (read-only for reads, write transactions for mutations) to prevent data races under concurrent access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)