### PR TITLE
Add explicit zero-value validation to API request handlers

### DIFF
--- a/internal/api/notes.go
+++ b/internal/api/notes.go
@@ -51,6 +51,11 @@ func (s *Server) CreateNote(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if body.Title == "" {
+		respondWithError(w, http.StatusBadRequest, "Title is required")
+		return
+	}
+
 	model, err := s.sqlStore.CreateNote(ctx, body.Title, body.Content)
 	if err != nil {
 		respondWithError(w, http.StatusInternalServerError, "Failed to create note")
@@ -83,6 +88,11 @@ func (s *Server) PutNote(w http.ResponseWriter, r *http.Request, id Id) {
 	var body PutNoteJSONRequestBody
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		respondWithError(w, http.StatusBadRequest, "Invalid request body")
+		return
+	}
+
+	if body.Title == "" {
+		respondWithError(w, http.StatusBadRequest, "Title is required")
 		return
 	}
 

--- a/internal/api/notes_integration_test.go
+++ b/internal/api/notes_integration_test.go
@@ -125,6 +125,38 @@ func TestNotesIntegration(t *testing.T) {
 		}
 	})
 
+	t.Run("create note with empty title returns bad request", func(t *testing.T) {
+		body := CreateNoteJSONBody{
+			Title:   "",
+			Content: "Some content",
+		}
+		b, _ := json.Marshal(body)
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/v1/notes", bytes.NewReader(b))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		srv.CreateNote(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("CreateNote status = %d, want %d; body = %s", w.Code, http.StatusBadRequest, w.Body.String())
+		}
+	})
+
+	t.Run("update note with empty title returns bad request", func(t *testing.T) {
+		body := PutNoteJSONBody{
+			Title:   "",
+			Content: "Some content",
+		}
+		b, _ := json.Marshal(body)
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodPut, "/api/v1/notes/"+uuid.UUID(noteID).String(), bytes.NewReader(b))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		srv.PutNote(w, req, noteID)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("PutNote status = %d, want %d; body = %s", w.Code, http.StatusBadRequest, w.Body.String())
+		}
+	})
+
 	t.Run("get nonexistent note returns not found", func(t *testing.T) {
 		fakeID := types.ID(uuid.Must(uuid.NewV4()))
 		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/v1/notes/"+uuid.UUID(fakeID).String(), nil)

--- a/internal/api/posts.go
+++ b/internal/api/posts.go
@@ -470,6 +470,11 @@ func (s *Server) PutPost(w http.ResponseWriter, r *http.Request, id Id) {
 		return
 	}
 
+	if uuid.UUID(post.ID) == uuid.Nil {
+		respondWithError(w, http.StatusBadRequest, "Post ID is required")
+		return
+	}
+
 	if uuid.UUID(post.ID) != postID {
 		respondWithError(w, http.StatusBadRequest, "Post ID mismatch: got %q in body but %q in URL", post.ID, postID)
 		return

--- a/internal/api/posts_integration_test.go
+++ b/internal/api/posts_integration_test.go
@@ -118,6 +118,23 @@ func TestPutPost(t *testing.T) {
 	if len(got.Tags) != 1 || got.Tags[0] != tagName {
 		t.Errorf("Tags = %v, want [%q]", got.Tags, tagName)
 	}
+
+	t.Run("put post with zero ID returns bad request", func(t *testing.T) {
+		zeroBody := pkgtypes.Post{
+			ID:       pkgtypes.ID(uuid.Nil),
+			MimeType: post.MimeType,
+			Note:     "test",
+		}
+		zb, _ := json.Marshal(zeroBody)
+		zReq := httptest.NewRequestWithContext(t.Context(), http.MethodPut, "/api/v1/posts/"+uuid.Nil.String(), bytes.NewReader(zb))
+		zReq.Header.Set("Content-Type", "application/json")
+		zW := httptest.NewRecorder()
+		srv.PutPost(zW, zReq, pkgtypes.ID(uuid.Nil))
+
+		if zW.Code != http.StatusBadRequest {
+			t.Fatalf("PutPost zero ID status = %d, want %d; body = %s", zW.Code, http.StatusBadRequest, zW.Body.String())
+		}
+	})
 }
 
 func TestDeletePost(t *testing.T) {

--- a/internal/api/tag_categories.go
+++ b/internal/api/tag_categories.go
@@ -121,6 +121,10 @@ func (s *Server) PutTagCategory(w http.ResponseWriter, r *http.Request, name Tag
 		}
 	}
 
+	if req.Color == "" {
+		req.Color = "#888888"
+	}
+
 	logger := zerolog.Ctx(ctx).With().Str("category", name).Logger()
 	now := time.Now().UTC()
 	model, isCreate, err := s.sqlStore.UpsertTagCategory(ctx, name, store.TagCategoryInput{

--- a/internal/api/tag_categories_integration_test.go
+++ b/internal/api/tag_categories_integration_test.go
@@ -124,6 +124,32 @@ func TestTagCategoriesIntegration(t *testing.T) {
 		}
 	})
 
+	t.Run("create tag category with empty color defaults color", func(t *testing.T) {
+		defaultColorCat := "default-color-cat-" + uuid.Must(uuid.NewV4()).String()[:8]
+		body := types.TagCategory{
+			Name:        defaultColorCat,
+			Description: "No color specified",
+			Color:       "",
+		}
+		b, _ := json.Marshal(body)
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodPut, "/api/v1/tagCategories/"+defaultColorCat, bytes.NewReader(b))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		srv.PutTagCategory(w, req, defaultColorCat)
+
+		if w.Code != http.StatusCreated {
+			t.Fatalf("PutTagCategory status = %d, want %d; body = %s", w.Code, http.StatusCreated, w.Body.String())
+		}
+
+		var cat types.TagCategory
+		if err := json.NewDecoder(w.Body).Decode(&cat); err != nil {
+			t.Fatalf("failed to decode response: %v", err)
+		}
+		if cat.Color != "#888888" {
+			t.Errorf("Color = %q, want %q", cat.Color, "#888888")
+		}
+	})
+
 	t.Run("delete tag category", func(t *testing.T) {
 		req := httptest.NewRequestWithContext(t.Context(), http.MethodDelete, "/api/v1/tagCategories/"+catName, nil)
 		w := httptest.NewRecorder()

--- a/internal/api/tags.go
+++ b/internal/api/tags.go
@@ -280,8 +280,12 @@ func (s *Server) ConvertTagToAlias(w http.ResponseWriter, r *http.Request, name 
 		return
 	}
 
-	if body.Target == "" || body.Target == name {
-		respondWithError(w, http.StatusBadRequest, "Invalid target tag")
+	if body.Target == "" {
+		respondWithError(w, http.StatusBadRequest, "Target tag name is required")
+		return
+	}
+	if body.Target == name {
+		respondWithError(w, http.StatusBadRequest, "Target must differ from source")
 		return
 	}
 

--- a/internal/api/tags_integration_test.go
+++ b/internal/api/tags_integration_test.go
@@ -237,6 +237,21 @@ func TestTagsIntegration(t *testing.T) {
 		}
 	})
 
+	t.Run("convert tag to alias with empty target returns bad request", func(t *testing.T) {
+		body := ConvertTagToAliasJSONRequestBody{
+			Target: "",
+		}
+		b, _ := json.Marshal(body)
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/api/v1/tags/"+tagName+"/convert-to-alias", bytes.NewReader(b))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		srv.ConvertTagToAlias(w, req, tagName)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("ConvertTagToAlias status = %d, want %d; body = %s", w.Code, http.StatusBadRequest, w.Body.String())
+		}
+	})
+
 	t.Run("delete tag", func(t *testing.T) {
 		req := httptest.NewRequestWithContext(t.Context(), http.MethodDelete, "/api/v1/tags/"+tagName, nil)
 		w := httptest.NewRecorder()


### PR DESCRIPTION
## Summary
- Validate empty note titles in `CreateNote` and `PutNote` (return 400)
- Validate zero-UUID post ID in `PutPost` (return 400)
- Split `ConvertTagToAlias` target validation into separate "required" and "must differ" checks
- Default tag category color to `#888888` when empty
- Add integration tests for all new validations

🤖 Generated with [Claude Code](https://claude.com/claude-code)