### PR TITLE
Add fallback text for posts with missing thumbnails

### DIFF
--- a/cmd/hyperboard-web/static/style.css
+++ b/cmd/hyperboard-web/static/style.css
@@ -232,9 +232,19 @@ button:hover,
 }
 
 .posts-item a {
-  display: block;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   width: 100%;
   height: 100%;
+  color: var(--base04);
+  text-decoration: none;
+  font-size: 0.85rem;
+}
+
+.posts-item a::before {
+  content: "View post";
+  position: absolute;
 }
 
 .posts-item img {


### PR DESCRIPTION
## Summary
- Posts in the grid that have no thumbnail (or a broken thumbnail) now show "View post" fallback text, making them clickable and discoverable
- Uses a CSS `::before` pseudo-element positioned behind the thumbnail image, so it only appears when the image is absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)