### PR TITLE
Prefetch pages ahead of scroll for smoother infinite scrolling

### DIFF
--- a/cmd/hyperboard-web/templates/posts.html
+++ b/cmd/hyperboard-web/templates/posts.html
@@ -133,6 +133,29 @@ updateTagFilterButtons();
     }, 200);
   });
 })();
+
+(function() {
+  var observer = new IntersectionObserver(function(entries) {
+    entries.forEach(function(entry) {
+      if (entry.isIntersecting) {
+        htmx.trigger(entry.target, 'prefetch');
+        observer.unobserve(entry.target);
+      }
+    });
+  }, { rootMargin: '200%' });
+
+  function observeTriggers() {
+    document.querySelectorAll('.scroll-trigger').forEach(function(el) {
+      observer.observe(el);
+    });
+  }
+
+  new MutationObserver(function() {
+    observeTriggers();
+  }).observe(document.getElementById('posts-grid'), { childList: true, subtree: true });
+
+  observeTriggers();
+})();
 </script>
 {{end}}
 
@@ -145,8 +168,9 @@ updateTagFilterButtons();
 </div>
 {{end}}
 {{if .NextCursor}}
-<div hx-get="/posts-partial?cursor={{.NextCursor}}&search={{$.Search}}"
-     hx-trigger="revealed"
+<div class="scroll-trigger"
+     hx-get="/posts-partial?cursor={{.NextCursor}}&search={{$.Search}}"
+     hx-trigger="prefetch"
      hx-swap="afterend"
      hx-target="this">
 </div>


### PR DESCRIPTION
## Summary
- Replace HTMX's `revealed` trigger with a custom IntersectionObserver using `rootMargin: '200%'`, so the next page begins loading ~2 viewports before the user reaches the bottom of the current content
- A MutationObserver watches for new trigger elements added by HTMX swaps, cascading prefetches as the user scrolls so multiple pages load ahead

🤖 Generated with [Claude Code](https://claude.com/claude-code)