### PR TITLE
Skip re-encoding WebP uploads

### DIFF
--- a/internal/media/image.go
+++ b/internal/media/image.go
@@ -86,6 +86,9 @@ func FitImage(img image.Image, maxW, maxH int) image.Image {
 	return dst
 }
 
+// MIMEWebP is the MIME type for WebP images.
+const MIMEWebP = "image/webp"
+
 // MaxWebPDimension is the maximum width/height allowed by the WebP specification.
 const MaxWebPDimension = 16383
 
@@ -108,13 +111,17 @@ func ProcessImage(data []byte, detectedMIME string) ([]byte, string, []byte, err
 		// Too large to convert — store original.
 		content = data
 		mime = detectedMIME
+	} else if detectedMIME == MIMEWebP {
+		// Already WebP — skip re-encoding to avoid quality loss.
+		content = data
+		mime = MIMEWebP
 	} else {
 		encoded, err := EncodeWebP(img, 85)
 		if err != nil {
 			return nil, "", nil, fmt.Errorf("encode webp: %w", err)
 		}
 		content = encoded
-		mime = "image/webp"
+		mime = MIMEWebP
 	}
 
 	// Generate thumbnail (512x512 max, preserve aspect ratio).

--- a/internal/media/image_test.go
+++ b/internal/media/image_test.go
@@ -70,7 +70,7 @@ func TestProcessImage(t *testing.T) { //nolint:paralleltest // requires cwebp bi
 		t.Skip("cwebp not available")
 	}
 
-	t.Run("small png to webp", func(t *testing.T) {
+	t.Run("small png to webp", func(t *testing.T) { //nolint:paralleltest // requires cwebp binary
 		img := syntheticColorImage(64, 64)
 		pngData := encodePNG(t, img)
 
@@ -78,11 +78,33 @@ func TestProcessImage(t *testing.T) { //nolint:paralleltest // requires cwebp bi
 		if err != nil {
 			t.Fatalf("ProcessImage error: %v", err)
 		}
-		if mime != "image/webp" {
-			t.Errorf("mime = %q, want %q", mime, "image/webp")
+		if mime != MIMEWebP {
+			t.Errorf("mime = %q, want %q", mime, MIMEWebP)
 		}
 		if len(content) == 0 {
 			t.Error("content should not be empty")
+		}
+		if len(thumbnail) == 0 {
+			t.Error("thumbnail should not be empty")
+		}
+	})
+
+	t.Run("webp passthrough", func(t *testing.T) { //nolint:paralleltest // requires cwebp binary
+		img := syntheticColorImage(64, 64)
+		webpData, err := EncodeWebP(img, 85)
+		if err != nil {
+			t.Fatalf("EncodeWebP error: %v", err)
+		}
+
+		content, mime, thumbnail, err := ProcessImage(webpData, MIMEWebP)
+		if err != nil {
+			t.Fatalf("ProcessImage error: %v", err)
+		}
+		if mime != MIMEWebP {
+			t.Errorf("mime = %q, want %q", mime, MIMEWebP)
+		}
+		if !bytes.Equal(content, webpData) {
+			t.Error("webp content should be returned unchanged")
 		}
 		if len(thumbnail) == 0 {
 			t.Error("thumbnail should not be empty")


### PR DESCRIPTION
## Summary
- When an uploaded image is already WebP and within dimension limits, skip the decode/re-encode cycle through cwebp
- Thumbnail generation still re-encodes as before (resize requires re-encoding)
- Adds `MIMEWebP` constant to satisfy goconst linter
- Adds test for WebP passthrough behavior

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)