### PR TITLE
Fix blank grid cell every 24 thumbnails

### DIFF
--- a/cmd/hyperboard-web/templates/posts.html
+++ b/cmd/hyperboard-web/templates/posts.html
@@ -147,7 +147,7 @@ updateTagFilterButtons();
 {{if .NextCursor}}
 <div hx-get="/posts-partial?cursor={{.NextCursor}}&search={{$.Search}}"
      hx-trigger="revealed"
-     hx-swap="afterend"
+     hx-swap="outerHTML"
      hx-target="this">
 </div>
 {{end}}


### PR DESCRIPTION
## Summary
- The infinite scroll sentinel div used `hx-swap="afterend"`, which kept the empty sentinel in the grid after loading the next page, creating a blank cell at each page boundary
- Switch to `hx-swap="outerHTML"` so each sentinel replaces itself with the next batch of post items (plus a new sentinel if more pages remain)

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)