### PR TITLE
Add regenerate thumbnail button to post view

### DIFF
--- a/cmd/hyperboard-web/handlers.go
+++ b/cmd/hyperboard-web/handlers.go
@@ -212,6 +212,29 @@ func (app *App) handlePostTags(w http.ResponseWriter, r *http.Request) {
 	app.renderTemplate(w, r, "post-tags", PostData{Post: *reResp.JSON200})
 }
 
+func (app *App) handleRegenerateThumbnail(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	id := r.PathValue("id")
+
+	postID, err := uuid.Parse(id)
+	if err != nil {
+		http.Error(w, "Invalid post ID", http.StatusBadRequest)
+		return
+	}
+
+	resp, err := app.api.RegeneratePostThumbnailWithResponse(ctx, postID)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Failed to regenerate thumbnail: %v", err), http.StatusInternalServerError)
+		return
+	}
+	if resp.StatusCode() >= 400 {
+		http.Error(w, fmt.Sprintf("Failed to regenerate thumbnail: %s", resp.Body), resp.StatusCode())
+		return
+	}
+
+	http.Redirect(w, r, "/posts/"+id, http.StatusSeeOther)
+}
+
 func (app *App) handleTagSuggestions(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	q := r.URL.Query().Get("q")

--- a/cmd/hyperboard-web/main.go
+++ b/cmd/hyperboard-web/main.go
@@ -116,6 +116,7 @@ func run() error {
 	protected.HandleFunc("/posts/{id}", app.handlePost)
 	protected.HandleFunc("/posts/{id}/note", app.handlePostNote)
 	protected.HandleFunc("/posts/{id}/tags", app.handlePostTags)
+	protected.HandleFunc("POST /posts/{id}/regenerate-thumbnail", app.handleRegenerateThumbnail)
 	protected.HandleFunc("/posts/{id}/tags/{tag}", app.handlePostTags)
 	protected.HandleFunc("/tag-suggestions", app.handleTagSuggestions)
 	protected.HandleFunc("/upload", app.handleUpload)

--- a/cmd/hyperboard-web/templates/post.html
+++ b/cmd/hyperboard-web/templates/post.html
@@ -85,7 +85,10 @@ function setMediaMode(mode) {
 </div>
 {{end}}
 
-<div class="mt-2">
+<div class="mt-2 flex gap-1">
+  <button class="btn"
+    hx-post="/posts/{{.Post.ID}}/regenerate-thumbnail"
+    hx-confirm="Regenerate thumbnail for this post?">Regenerate Thumbnail</button>
   <button class="btn btn-danger"
     hx-delete="/posts/{{.Post.ID}}"
     hx-confirm="Delete this post?"

--- a/internal/api/gen.go
+++ b/internal/api/gen.go
@@ -213,6 +213,9 @@ type ServerInterface interface {
 	// Get posts that are visually similar to the given post based on perceptual hash.
 	// (GET /api/v1/posts/{id}/similar)
 	GetSimilarPosts(w http.ResponseWriter, r *http.Request, id Id, params GetSimilarPostsParams)
+	// Regenerate the thumbnail for a post from its existing content.
+	// (POST /api/v1/posts/{id}/thumbnail)
+	RegeneratePostThumbnail(w http.ResponseWriter, r *http.Request, id Id)
 	// Replace a post's thumbnail image. The server processes the image into a WebP thumbnail.
 	// (PUT /api/v1/posts/{id}/thumbnail)
 	ReplacePostThumbnail(w http.ResponseWriter, r *http.Request, id Id)
@@ -539,6 +542,31 @@ func (siw *ServerInterfaceWrapper) GetSimilarPosts(w http.ResponseWriter, r *htt
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.GetSimilarPosts(w, r, id, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// RegeneratePostThumbnail operation middleware
+func (siw *ServerInterfaceWrapper) RegeneratePostThumbnail(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "id" -------------
+	var id Id
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.RegeneratePostThumbnail(w, r, id)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -1018,6 +1046,7 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	m.HandleFunc("PUT "+options.BaseURL+"/api/v1/posts/{id}", wrapper.PutPost)
 	m.HandleFunc("PUT "+options.BaseURL+"/api/v1/posts/{id}/content", wrapper.ReplacePostContent)
 	m.HandleFunc("GET "+options.BaseURL+"/api/v1/posts/{id}/similar", wrapper.GetSimilarPosts)
+	m.HandleFunc("POST "+options.BaseURL+"/api/v1/posts/{id}/thumbnail", wrapper.RegeneratePostThumbnail)
 	m.HandleFunc("PUT "+options.BaseURL+"/api/v1/posts/{id}/thumbnail", wrapper.ReplacePostThumbnail)
 	m.HandleFunc("GET "+options.BaseURL+"/api/v1/tagCategories", wrapper.GetTagCategories)
 	m.HandleFunc("DELETE "+options.BaseURL+"/api/v1/tagCategories/{tagCategory}", wrapper.DeleteTagCategory)

--- a/internal/api/posts.go
+++ b/internal/api/posts.go
@@ -675,6 +675,78 @@ func (s *Server) ReplacePostThumbnail(w http.ResponseWriter, r *http.Request, id
 	respond(w, http.StatusOK, postFromModel(model))
 }
 
+func (s *Server) RegeneratePostThumbnail(w http.ResponseWriter, r *http.Request, id Id) {
+	ctx := r.Context()
+	logger := zerolog.Ctx(ctx).With().Stringer("post_id", uuid.UUID(id)).Logger()
+
+	postID := uuid.UUID(id)
+
+	post, err := s.sqlStore.GetPost(ctx, postID)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			respondWithError(w, http.StatusNotFound, "Post not found")
+			return
+		}
+		respondWithError(w, http.StatusInternalServerError, "Failed to retrieve post")
+		return
+	}
+
+	contentKey := storageKeyForContent(postID, post.MimeType)
+	obj, err := s.mediaStore.Download(ctx, contentKey)
+	if err != nil {
+		logger.Error().Err(err).Str("key", contentKey).Msg("failed to download content from storage")
+		respondWithError(w, http.StatusInternalServerError, "Failed to download content")
+		return
+	}
+	data, err := io.ReadAll(obj.Body)
+	_ = obj.Body.Close()
+	if err != nil {
+		respondWithError(w, http.StatusInternalServerError, "Failed to read content")
+		return
+	}
+
+	var thumbnailData []byte
+	if strings.HasPrefix(post.MimeType, "image/") {
+		_, _, thumbnailData, err = media.ProcessImage(data, post.MimeType)
+		if err != nil {
+			logger.Error().Err(err).Msg("failed to process image for thumbnail regeneration")
+			respondWithError(w, http.StatusUnprocessableEntity, "Failed to process image: %v", err)
+			return
+		}
+	} else if strings.HasPrefix(post.MimeType, "video/") {
+		thumbnailData, err = media.RegenerateVideoThumbnail(data)
+		if err != nil {
+			logger.Error().Err(err).Msg("failed to process video for thumbnail regeneration")
+			respondWithError(w, http.StatusUnprocessableEntity, "Failed to process video: %v", err)
+			return
+		}
+	} else {
+		respondWithError(w, http.StatusUnprocessableEntity, "Cannot regenerate thumbnail for MIME type: %s", post.MimeType)
+		return
+	}
+
+	thumbnailKey := storageKeyForThumbnail(postID)
+	thumbnailURL, err := s.mediaStore.Upload(ctx, thumbnailKey, thumbnailData, "image/webp")
+	if err != nil {
+		respondWithError(w, http.StatusInternalServerError, "Failed to upload thumbnail")
+		return
+	}
+
+	now := time.Now().UTC()
+	model, err := s.sqlStore.UpdatePostThumbnail(ctx, postID, thumbnailURL, now)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			respondWithError(w, http.StatusNotFound, "Post not found")
+			return
+		}
+		respondWithError(w, http.StatusInternalServerError, "Failed to update post")
+		return
+	}
+
+	logger.Info().Msg("thumbnail regenerated")
+	respond(w, http.StatusOK, postFromModel(model))
+}
+
 func (s *Server) DeletePost(w http.ResponseWriter, r *http.Request, id Id) {
 	ctx := r.Context()
 

--- a/internal/api/spec/api-spec.yaml
+++ b/internal/api/spec/api-spec.yaml
@@ -357,6 +357,28 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerErrorResponse"
   /api/v1/posts/{id}/thumbnail:
+    post:
+      operationId: regeneratePostThumbnail
+      summary: Regenerate the thumbnail for a post from its existing content.
+      parameters:
+        - $ref: "#/components/parameters/id"
+      responses:
+        "200":
+          $ref: "#/components/responses/PostResponse"
+        "400":
+          $ref: "#/components/responses/BadRequestResponse"
+        "401":
+          $ref: "#/components/responses/UnauthorizedResponse"
+        "403":
+          $ref: "#/components/responses/ForbiddenResponse"
+        "404":
+          $ref: "#/components/responses/NotFoundResponse"
+        "422":
+          $ref: "#/components/responses/BadRequestResponse"
+        "429":
+          $ref: "#/components/responses/TooManyRequestsResponse"
+        "500":
+          $ref: "#/components/responses/InternalServerErrorResponse"
     put:
       operationId: replacePostThumbnail
       summary: Replace a post's thumbnail image. The server processes the image into a WebP thumbnail.

--- a/internal/media/video.go
+++ b/internal/media/video.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"image"
+	"math/rand/v2"
 	"os"
 	"os/exec"
 	"strconv"
@@ -113,4 +114,28 @@ func ProcessVideo(data []byte) ([]byte, bool, error) {
 	}
 
 	return thumbBytes, hasAudio, nil
+}
+
+// RegenerateVideoThumbnail extracts a thumbnail from a random frame between
+// 25% and 75% of the video duration.
+func RegenerateVideoThumbnail(data []byte) ([]byte, error) {
+	tmpFile, err := os.CreateTemp("", "hyperboard-video-*")
+	if err != nil {
+		return nil, fmt.Errorf("create temp file: %w", err)
+	}
+	defer func() { _ = os.Remove(tmpFile.Name()) }()
+
+	if _, err := tmpFile.Write(data); err != nil {
+		_ = tmpFile.Close()
+		return nil, fmt.Errorf("write temp file: %w", err)
+	}
+	_ = tmpFile.Close()
+
+	offset := 1.0
+	if duration, err := probeDuration(tmpFile.Name()); err == nil && duration > 0 {
+		// Pick a random position between 25% and 75% of the video.
+		offset = duration * (0.25 + rand.Float64()*0.50) //nolint:gosec // not security-sensitive
+	}
+
+	return extractThumbnail(tmpFile.Name(), offset)
 }

--- a/pkg/client/gen.go
+++ b/pkg/client/gen.go
@@ -294,6 +294,9 @@ type ClientInterface interface {
 	// GetSimilarPosts request
 	GetSimilarPosts(ctx context.Context, id Id, params *GetSimilarPostsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// RegeneratePostThumbnail request
+	RegeneratePostThumbnail(ctx context.Context, id Id, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// ReplacePostThumbnailWithBody request with any body
 	ReplacePostThumbnailWithBody(ctx context.Context, id Id, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -501,6 +504,18 @@ func (c *Client) ReplacePostContentWithBody(ctx context.Context, id Id, contentT
 
 func (c *Client) GetSimilarPosts(ctx context.Context, id Id, params *GetSimilarPostsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetSimilarPostsRequest(c.Server, id, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) RegeneratePostThumbnail(ctx context.Context, id Id, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRegeneratePostThumbnailRequest(c.Server, id)
 	if err != nil {
 		return nil, err
 	}
@@ -1185,6 +1200,40 @@ func NewGetSimilarPostsRequest(server string, id Id, params *GetSimilarPostsPara
 	return req, nil
 }
 
+// NewRegeneratePostThumbnailRequest generates requests for RegeneratePostThumbnail
+func NewRegeneratePostThumbnailRequest(server string, id Id) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "id", runtime.ParamLocationPath, id)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/posts/%s/thumbnail", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewReplacePostThumbnailRequestWithBody generates requests for ReplacePostThumbnail with any type of body
 func NewReplacePostThumbnailRequestWithBody(server string, id Id, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
@@ -1842,6 +1891,9 @@ type ClientWithResponsesInterface interface {
 	// GetSimilarPostsWithResponse request
 	GetSimilarPostsWithResponse(ctx context.Context, id Id, params *GetSimilarPostsParams, reqEditors ...RequestEditorFn) (*GetSimilarPostsResponse, error)
 
+	// RegeneratePostThumbnailWithResponse request
+	RegeneratePostThumbnailWithResponse(ctx context.Context, id Id, reqEditors ...RequestEditorFn) (*RegeneratePostThumbnailResponse, error)
+
 	// ReplacePostThumbnailWithBodyWithResponse request with any body
 	ReplacePostThumbnailWithBodyWithResponse(ctx context.Context, id Id, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ReplacePostThumbnailResponse, error)
 
@@ -2182,6 +2234,35 @@ func (r GetSimilarPostsResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r GetSimilarPostsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type RegeneratePostThumbnailResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *PostResponse
+	JSON400      *BadRequestResponse
+	JSON401      *UnauthorizedResponse
+	JSON403      *ForbiddenResponse
+	JSON404      *NotFoundResponse
+	JSON422      *BadRequestResponse
+	JSON429      *TooManyRequestsResponse
+	JSON500      *InternalServerErrorResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r RegeneratePostThumbnailResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r RegeneratePostThumbnailResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -2677,6 +2758,15 @@ func (c *ClientWithResponses) GetSimilarPostsWithResponse(ctx context.Context, i
 		return nil, err
 	}
 	return ParseGetSimilarPostsResponse(rsp)
+}
+
+// RegeneratePostThumbnailWithResponse request returning *RegeneratePostThumbnailResponse
+func (c *ClientWithResponses) RegeneratePostThumbnailWithResponse(ctx context.Context, id Id, reqEditors ...RequestEditorFn) (*RegeneratePostThumbnailResponse, error) {
+	rsp, err := c.RegeneratePostThumbnail(ctx, id, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRegeneratePostThumbnailResponse(rsp)
 }
 
 // ReplacePostThumbnailWithBodyWithResponse request with arbitrary body returning *ReplacePostThumbnailResponse
@@ -3480,6 +3570,81 @@ func ParseGetSimilarPostsResponse(rsp *http.Response) (*GetSimilarPostsResponse,
 			return nil, err
 		}
 		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 429:
+		var dest TooManyRequestsResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON429 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalServerErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseRegeneratePostThumbnailResponse parses an HTTP response from a RegeneratePostThumbnailWithResponse call
+func ParseRegeneratePostThumbnailResponse(rsp *http.Response) (*RegeneratePostThumbnailResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &RegeneratePostThumbnailResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest PostResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequestResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest UnauthorizedResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest ForbiddenResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFoundResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest BadRequestResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 429:
 		var dest TooManyRequestsResponse


### PR DESCRIPTION
## Summary
- Add `POST /api/v1/posts/{id}/thumbnail` API endpoint that regenerates a post's thumbnail from existing content
- For videos, picks a random frame between 25–75% of the duration (initial upload still uses 30%)
- For images, re-extracts the thumbnail from the stored image
- Add "Regenerate Thumbnail" button to the post detail page, placed to the left of the Delete button
- Add `RegenerateVideoThumbnail` function in the media package for random-frame extraction

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)