### PR TITLE
Add play indicator on video post thumbnails

### DIFF
--- a/cmd/hyperboard-web/static/style.css
+++ b/cmd/hyperboard-web/static/style.css
@@ -249,6 +249,25 @@ button:hover,
   border-color: var(--base0D);
 }
 
+/* Video play indicator */
+.video-indicator {
+  position: absolute;
+  bottom: 6px;
+  left: 6px;
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-width: 6px 0 6px 10px;
+  border-color: transparent transparent transparent rgba(255, 255, 255, 0.85);
+  filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.5));
+  pointer-events: none;
+}
+
+.similar-post-link {
+  position: relative;
+  display: inline-block;
+}
+
 /* Post detail */
 .post-media-controls {
   display: flex;

--- a/cmd/hyperboard-web/templatefuncs.go
+++ b/cmd/hyperboard-web/templatefuncs.go
@@ -68,6 +68,7 @@ func templateFuncs() template.FuncMap {
 			}
 			return string(b)
 		},
+		"hasPrefix": strings.HasPrefix,
 		"mediaUrl": func(rawURL string) string {
 			u, err := url.Parse(rawURL)
 			if err != nil {

--- a/cmd/hyperboard-web/templates/post.html
+++ b/cmd/hyperboard-web/templates/post.html
@@ -77,8 +77,9 @@ function setMediaMode(mode) {
   <h3>Similar Posts</h3>
   <div class="similar-posts-grid">
     {{range .SimilarPosts}}
-    <a href="/posts/{{.ID}}">
+    <a href="/posts/{{.ID}}" class="similar-post-link">
       <img class="similar-thumb" src="{{.ThumbnailUrl | mediaUrl}}" alt="Similar post">
+      {{if hasPrefix .MimeType "video/"}}<span class="video-indicator" aria-label="Video"></span>{{end}}
     </a>
     {{end}}
   </div>

--- a/cmd/hyperboard-web/templates/posts.html
+++ b/cmd/hyperboard-web/templates/posts.html
@@ -141,6 +141,7 @@ updateTagFilterButtons();
 <div class="posts-item">
   <a href="/posts/{{.ID}}">
     <img src="{{.ThumbnailUrl | mediaUrl}}" alt="Post {{.ID}}" loading="lazy">
+    {{if hasPrefix .MimeType "video/"}}<span class="video-indicator" aria-label="Video"></span>{{end}}
   </a>
 </div>
 {{end}}


### PR DESCRIPTION
## Summary
- Adds a small white play triangle in the bottom-left corner of video post thumbnails in the main grid and similar posts grid
- Uses a CSS border trick for the triangle with a drop shadow for visibility against any background
- Adds a `hasPrefix` template function for MIME type detection in templates

🤖 Generated with [Claude Code](https://claude.com/claude-code)