### PR TITLE
Fix "New Note" button triggering invalid UUID error

### DIFF
--- a/cmd/hyperboard-web/templates/notes.html
+++ b/cmd/hyperboard-web/templates/notes.html
@@ -6,7 +6,9 @@
 {{if .Error}}<div class="alert-error">{{.Error}}</div>{{end}}
 <div class="flex items-center gap-2 mt-1">
   <h1>Notes</h1>
-  <a href="/notes/_new" class="btn btn-primary">New Note</a>
+  <form method="POST" action="/notes" style="display:inline">
+    <button type="submit" class="btn btn-primary">New Note</button>
+  </form>
 </div>
 <table class="data-table mt-2" id="notes-table">
   <thead>


### PR DESCRIPTION
## Summary

- The "New Note" button was an `<a>` tag linking to `/notes/_new`, which routed to `handleNote` with `id="_new"` (4 characters) and failed `uuid.Parse` with "invalid UUID length: 4"
- Changed it to a `<form method="POST" action="/notes">` so it hits `handleNotes`, which creates the note and redirects to its UUID-based URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)