### PR TITLE
Color tag badge left-bars by category color on post view

### DIFF
--- a/cmd/hyperboard-web/templatefuncs.go
+++ b/cmd/hyperboard-web/templatefuncs.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 )
 
+const defaultColor = "var(--base03)"
+
 func mediaPath(rawURL string) string {
 	u, err := url.Parse(rawURL)
 	if err != nil {
@@ -41,12 +43,21 @@ func templateFuncs() template.FuncMap {
 		},
 		"catColor": func(colors map[string]string, cat *string) string {
 			if cat == nil || colors == nil {
-				return "var(--base03)"
+				return defaultColor
 			}
 			if c, ok := colors[*cat]; ok {
 				return c
 			}
-			return "var(--base03)"
+			return defaultColor
+		},
+		"tagColor": func(colors *map[string]string, tag string) string {
+			if colors == nil {
+				return defaultColor
+			}
+			if c, ok := (*colors)[tag]; ok {
+				return c
+			}
+			return defaultColor
 		},
 		"not": func(b bool) bool { return !b },
 		"formatSize": func(bytes int64) string {

--- a/cmd/hyperboard-web/templates/post.html
+++ b/cmd/hyperboard-web/templates/post.html
@@ -103,13 +103,13 @@ function setMediaMode(mode) {
   {{if or .Post.Tags .Post.CascadingTags}}
   <div class="post-tags-list">
     {{range .Post.Tags}}
-    <span class="badge">
+    <span class="badge" style="border-left-color: {{tagColor $.Post.TagColors .}}">
       <a href="/?search={{.}}" class="badge-link">{{.}}</a>
       <a class="badge-remove" hx-delete="/posts/{{$.Post.ID}}/tags/{{.}}" hx-target=".post-tags" hx-swap="outerHTML">×</a>
     </span>
     {{end}}
     {{if .Post.CascadingTags}}{{range deref_strings .Post.CascadingTags}}
-    <span class="badge badge-cascade">
+    <span class="badge badge-cascade" style="border-left-color: {{tagColor $.Post.TagColors .}}">
       <a href="/?search={{.}}" class="badge-link">{{.}}</a>
     </span>
     {{end}}{{end}}

--- a/internal/api/posts.go
+++ b/internal/api/posts.go
@@ -34,12 +34,19 @@ func postFromModel(model *models.Post) types.Post {
 		UpdatedAt:    model.UpdatedAt,
 	}
 
-	// Extract tag names from loaded tags
+	// Extract tag names and colors from loaded tags
 	tagNames := make([]types.TagName, 0, len(model.Tags))
+	tagColors := make(map[string]string)
 	for _, tag := range model.Tags {
 		tagNames = append(tagNames, tag.Name)
+		if tag.TagCategory != nil && tag.TagCategory.Color != "" {
+			tagColors[tag.Name] = tag.TagCategory.Color
+		}
 	}
 	post.Tags = tagNames
+	if len(tagColors) > 0 {
+		post.TagColors = &tagColors
+	}
 
 	return post
 }

--- a/internal/api/spec/types-spec.yaml
+++ b/internal/api/spec/types-spec.yaml
@@ -98,6 +98,10 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/TagName"
+        tagColors:
+          type: object
+          additionalProperties:
+            type: string
         cascadingTags:
           type: array
           items:

--- a/internal/db/store/posts.go
+++ b/internal/db/store/posts.go
@@ -43,7 +43,7 @@ func loadPostTags(ctx context.Context, querier interface {
 	}
 
 	query := fmt.Sprintf(
-		"SELECT pt.post_id, t.id, t.name FROM posts_tags pt JOIN tags t ON pt.tag_id = t.id WHERE pt.post_id IN (%s) ORDER BY t.name",
+		"SELECT pt.post_id, t.id, t.name, tc.color FROM posts_tags pt JOIN tags t ON pt.tag_id = t.id LEFT JOIN tag_categories tc ON t.tag_category_id = tc.id WHERE pt.post_id IN (%s) ORDER BY t.name",
 		strings.Join(placeholders, ", "),
 	)
 
@@ -56,8 +56,12 @@ func loadPostTags(ctx context.Context, querier interface {
 	for rows.Next() {
 		var postID uuid.UUID
 		var tag models.Tag
-		if err := rows.Scan(&postID, &tag.ID, &tag.Name); err != nil {
+		var color sql.NullString
+		if err := rows.Scan(&postID, &tag.ID, &tag.Name, &color); err != nil {
 			return err
+		}
+		if color.Valid {
+			tag.TagCategory = &models.TagCategory{Color: color.String}
 		}
 		if p, ok := postsByID[postID]; ok {
 			p.Tags = append(p.Tags, &tag)

--- a/pkg/types/gen.go
+++ b/pkg/types/gen.go
@@ -26,16 +26,17 @@ type Note struct {
 
 // Post defines model for Post.
 type Post struct {
-	CascadingTags *[]TagName `json:"cascadingTags,omitempty"`
-	ContentUrl    URL        `json:"contentUrl"`
-	CreatedAt     Timestamp  `json:"createdAt"`
-	HasAudio      bool       `json:"hasAudio"`
-	ID            ID         `json:"id"`
-	MimeType      string     `json:"mimeType"`
-	Note          string     `json:"note"`
-	Tags          []TagName  `json:"tags"`
-	ThumbnailUrl  URL        `json:"thumbnailUrl"`
-	UpdatedAt     Timestamp  `json:"updatedAt"`
+	CascadingTags *[]TagName         `json:"cascadingTags,omitempty"`
+	ContentUrl    URL                `json:"contentUrl"`
+	CreatedAt     Timestamp          `json:"createdAt"`
+	HasAudio      bool               `json:"hasAudio"`
+	ID            ID                 `json:"id"`
+	MimeType      string             `json:"mimeType"`
+	Note          string             `json:"note"`
+	TagColors     *map[string]string `json:"tagColors,omitempty"`
+	Tags          []TagName          `json:"tags"`
+	ThumbnailUrl  URL                `json:"thumbnailUrl"`
+	UpdatedAt     Timestamp          `json:"updatedAt"`
 }
 
 // Tag defines model for Tag.


### PR DESCRIPTION
## Summary
- Add `tagColors` field to Post API schema mapping tag names to their category hex colors
- Extend `loadPostTags` SQL query to LEFT JOIN `tag_categories` and load category colors
- Apply category colors as `border-left-color` on tag badge spans (both regular and cascading) in the post view

🤖 Generated with [Claude Code](https://claude.com/claude-code)