### PR TITLE
Default posts page to random sort

### DIFF
--- a/cmd/hyperboard-web/handlers.go
+++ b/cmd/hyperboard-web/handlers.go
@@ -19,6 +19,9 @@ const newResourceName = "_new"
 func (app *App) handlePosts(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	search := r.URL.Query().Get("search")
+	if search == "" {
+		search = "sort:random"
+	}
 	cursor := r.URL.Query().Get("cursor")
 
 	limit := 24


### PR DESCRIPTION
## Summary
- When no search query is provided, the posts page now defaults to `sort:random` so the landing page shows posts in random order and the Random sort button appears active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)