### PR TITLE
Add GoDoc comments for all undocumented symbols

### DIFF
--- a/internal/api/cmd.go
+++ b/internal/api/cmd.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/viper"
 )
 
+// configPath is the path to the configuration file, set via the --config CLI flag.
 var configPath string
 
 // NewCommand returns the cobra command for the hyperboard-api server.
@@ -38,6 +39,7 @@ func NewCommand() *cobra.Command {
 	return cmd
 }
 
+// initConfig reads the configuration file if configPath is set.
 func initConfig() {
 	if configPath != "" {
 		viper.SetConfigFile(configPath)
@@ -47,6 +49,7 @@ func initConfig() {
 	}
 }
 
+// run initializes and starts the API server with the given context.
 func run(ctx context.Context) error {
 	cfg := loadConfig()
 
@@ -75,6 +78,7 @@ func run(ctx context.Context) error {
 	return serveAPI(ctx, cfg, dsn)
 }
 
+// serveAPI sets up the HTTP server, storage backends, database connection, and starts serving the API.
 func serveAPI(ctx context.Context, cfg *config, dsn string) error {
 	objStorage, err := s3storage.New(
 		ctx,

--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/viper"
 )
 
+// config holds the configuration for the API server.
 type config struct {
 	Port                string
 	AdminPassword       string
@@ -16,6 +17,7 @@ type config struct {
 	ObjectStore         objectStoreConfig
 }
 
+// sqlStoreConfig holds PostgreSQL connection configuration.
 type sqlStoreConfig struct {
 	Host     string
 	User     string
@@ -24,6 +26,7 @@ type sqlStoreConfig struct {
 	SSLMode  string
 }
 
+// objectStoreConfig holds S3-compatible object store configuration.
 type objectStoreConfig struct {
 	Endpoint     string
 	Bucket       string
@@ -33,6 +36,7 @@ type objectStoreConfig struct {
 	UsePathStyle bool
 }
 
+// bindConfig registers CLI flags and environment variable bindings for the API server configuration.
 func bindConfig(cmd *cobra.Command) {
 	flags := cmd.Flags()
 
@@ -61,6 +65,7 @@ func bindConfig(cmd *cobra.Command) {
 	_ = viper.BindPFlags(flags)
 }
 
+// loadConfig reads configuration values from viper and returns a populated config struct.
 func loadConfig() *config {
 	return &config{
 		Port:                viper.GetString("port"),

--- a/internal/api/health.go
+++ b/internal/api/health.go
@@ -6,10 +6,12 @@ import (
 	"time"
 )
 
+// GetHealth handles liveness probe requests.
 func (s *Server) GetHealth(w http.ResponseWriter, r *http.Request) {
 	respond(w, http.StatusOK, "OK")
 }
 
+// GetReadiness handles readiness probe requests by checking connectivity to the database and object store.
 func (s *Server) GetReadiness(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
 	defer cancel()

--- a/internal/api/list.go
+++ b/internal/api/list.go
@@ -2,6 +2,7 @@ package api
 
 import "encoding/base64"
 
+// MaxLimit is the maximum number of items that can be returned per page.
 const MaxLimit = 64
 
 // obfuscateCursor encodes a string into an opaque cursor.

--- a/internal/api/metrics.go
+++ b/internal/api/metrics.go
@@ -4,5 +4,6 @@ import (
 	"net/http"
 )
 
+// GetMetrics handles metrics endpoint requests.
 func (s *Server) GetMetrics(w http.ResponseWriter, r *http.Request) {
 }

--- a/internal/api/notes.go
+++ b/internal/api/notes.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rs/zerolog"
 )
 
+// noteFromModel converts a database Note model to an API Note type.
 func noteFromModel(model *models.Note) types.Note {
 	return types.Note{
 		ID:        types.ID(model.ID),
@@ -22,6 +23,7 @@ func noteFromModel(model *models.Note) types.Note {
 	}
 }
 
+// GetNotes handles listing all notes.
 func (s *Server) GetNotes(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
@@ -42,6 +44,7 @@ func (s *Server) GetNotes(w http.ResponseWriter, r *http.Request) {
 	respond(w, http.StatusOK, resp)
 }
 
+// CreateNote handles creating a new note.
 func (s *Server) CreateNote(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
@@ -66,6 +69,7 @@ func (s *Server) CreateNote(w http.ResponseWriter, r *http.Request) {
 	respond(w, http.StatusCreated, noteFromModel(model))
 }
 
+// GetNote handles retrieving a single note by ID.
 func (s *Server) GetNote(w http.ResponseWriter, r *http.Request, id Id) {
 	ctx := r.Context()
 
@@ -82,6 +86,7 @@ func (s *Server) GetNote(w http.ResponseWriter, r *http.Request, id Id) {
 	respond(w, http.StatusOK, noteFromModel(model))
 }
 
+// PutNote handles updating an existing note.
 func (s *Server) PutNote(w http.ResponseWriter, r *http.Request, id Id) {
 	ctx := r.Context()
 

--- a/internal/api/posts.go
+++ b/internal/api/posts.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rs/zerolog"
 )
 
+// postFromModel converts a database Post model to an API Post type.
 func postFromModel(model *models.Post) types.Post {
 	post := types.Post{
 		ID:           types.ID(model.ID),
@@ -43,6 +44,7 @@ func postFromModel(model *models.Post) types.Post {
 	return post
 }
 
+// GetPosts handles paginated post listing with search, filtering, and cursor-based pagination.
 func (s *Server) GetPosts(w http.ResponseWriter, r *http.Request, params GetPostsParams) {
 	ctx := r.Context()
 	logger := *zerolog.Ctx(ctx)

--- a/internal/api/responses.go
+++ b/internal/api/responses.go
@@ -8,6 +8,7 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+// respond writes a JSON response with the given status code and body.
 func respond(w http.ResponseWriter, code int, body any) {
 	if body == nil {
 		w.WriteHeader(code)
@@ -25,6 +26,7 @@ func respond(w http.ResponseWriter, code int, body any) {
 	}
 }
 
+// respondWithError writes a JSON error response with a formatted message.
 func respondWithError(w http.ResponseWriter, code int, message string, args ...any) {
 	e := Error{Message: fmt.Sprintf(message, args...)}
 	b, err := json.Marshal(e)

--- a/internal/api/search.go
+++ b/internal/api/search.go
@@ -9,6 +9,7 @@ import (
 	"github.com/dharmab/hyperboard/pkg/types"
 )
 
+// parseSearch parses a comma-separated search query string into a Query.
 func parseSearch(query string) search.Query {
 	postSearch := search.Query{
 		IncludedTags: []types.TagName{},
@@ -52,17 +53,20 @@ func parseSearch(query string) search.Query {
 	return postSearch
 }
 
+// postCursor holds cursor state for deterministic post pagination.
 type postCursor struct {
 	Timestamp string `json:"t"`
 	ID        string `json:"id"`
 }
 
+// encodePostCursor serializes a postCursor to a base64-encoded string.
 func encodePostCursor(pc postCursor) string {
 	//nolint:errchkjson // postCursor contains only string fields, json.Marshal cannot fail
 	data, _ := json.Marshal(pc)
 	return base64.URLEncoding.EncodeToString(data)
 }
 
+// decodePostCursor deserializes a base64-encoded string into a postCursor.
 func decodePostCursor(s string) (postCursor, error) {
 	data, err := base64.URLEncoding.DecodeString(s)
 	if err != nil {
@@ -72,17 +76,20 @@ func decodePostCursor(s string) (postCursor, error) {
 	return pc, json.Unmarshal(data, &pc)
 }
 
+// randomCursor holds cursor state for random-order post pagination.
 type randomCursor struct {
 	Seed   int64 `json:"seed"`
 	Offset int   `json:"offset"`
 }
 
+// encodeRandomCursor serializes a randomCursor to a base64-encoded string.
 func encodeRandomCursor(rc randomCursor) string {
 	//nolint:errchkjson // randomCursor contains only primitive fields, json.Marshal cannot fail
 	data, _ := json.Marshal(rc)
 	return base64.URLEncoding.EncodeToString(data)
 }
 
+// decodeRandomCursor deserializes a base64-encoded string into a randomCursor.
 func decodeRandomCursor(s string, rc *randomCursor) error {
 	data, err := base64.URLEncoding.DecodeString(s)
 	if err != nil {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -5,6 +5,7 @@ import (
 	"github.com/dharmab/hyperboard/internal/storage"
 )
 
+// Server implements the API server interface with SQL and media store dependencies.
 type Server struct {
 	sqlStore   store.SQLStore
 	mediaStore storage.MediaStore
@@ -12,6 +13,7 @@ type Server struct {
 
 var _ ServerInterface = &Server{}
 
+// NewServer creates a new Server with the given SQL and media stores.
 func NewServer(sqlStore store.SQLStore, mediaStore storage.MediaStore) *Server {
 	return &Server{
 		sqlStore:   sqlStore,

--- a/internal/api/similar.go
+++ b/internal/api/similar.go
@@ -17,6 +17,7 @@ type SimilarPostsResponse struct {
 	Similar []types.Post `json:"similar"`
 }
 
+// GetSimilarPosts handles requests to find posts visually similar to a given post.
 func (s *Server) GetSimilarPosts(w http.ResponseWriter, r *http.Request, id Id, params GetSimilarPostsParams) {
 	ctx := r.Context()
 

--- a/internal/api/tagcategories.go
+++ b/internal/api/tagcategories.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rs/zerolog"
 )
 
+// tagCategoryFromModel converts a database TagCategory model to an API TagCategory type.
 func tagCategoryFromModel(model *models.TagCategory) types.TagCategory {
 	return types.TagCategory{
 		Name:        model.Name,
@@ -23,6 +24,7 @@ func tagCategoryFromModel(model *models.TagCategory) types.TagCategory {
 	}
 }
 
+// GetTagCategories handles paginated tag category listing with cursor-based pagination.
 func (s *Server) GetTagCategories(w http.ResponseWriter, r *http.Request, params GetTagCategoriesParams) {
 	ctx := r.Context()
 

--- a/internal/api/tags.go
+++ b/internal/api/tags.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rs/zerolog"
 )
 
+// tagFromModel converts a database Tag model to an API Tag type.
 func tagFromModel(model *models.Tag) types.Tag {
 	tag := types.Tag{
 		Name:        model.Name,
@@ -32,6 +33,7 @@ func tagFromModel(model *models.Tag) types.Tag {
 	return tag
 }
 
+// GetTags handles paginated tag listing with cursor-based pagination.
 func (s *Server) GetTags(w http.ResponseWriter, r *http.Request, params GetTagsParams) {
 	ctx := r.Context()
 

--- a/internal/api/upload.go
+++ b/internal/api/upload.go
@@ -18,6 +18,7 @@ import (
 	"github.com/rs/zerolog"
 )
 
+// UploadPost handles uploading new media content as a post.
 func (s *Server) UploadPost(w http.ResponseWriter, r *http.Request, params UploadPostParams) {
 	ctx := r.Context()
 	logger := *zerolog.Ctx(ctx)

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/viper"
 )
 
+// App holds CLI application state including configuration, commands, and output format.
 type App struct {
 	Config       *Config
 	OutputFormat string
@@ -21,6 +22,7 @@ type App struct {
 	configPath string
 }
 
+// NewApp creates and configures a new CLI application with all root-level commands.
 func NewApp() *App {
 	a := &App{}
 

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -9,6 +9,7 @@ import (
 	"github.com/dharmab/hyperboard/pkg/client"
 )
 
+// NewClient creates an authenticated API client using the app's configuration.
 func (a *App) NewClient() (*client.ClientWithResponses, error) {
 	return client.NewClientWithResponses(
 		a.Config.APIURL,
@@ -19,6 +20,7 @@ func (a *App) NewClient() (*client.ClientWithResponses, error) {
 	)
 }
 
+// CheckResponse returns an error if the HTTP status code indicates a failure.
 func CheckResponse(statusCode int, body []byte) error {
 	if statusCode >= 400 {
 		return fmt.Errorf("server returned %d: %s", statusCode, body)

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -8,11 +8,13 @@ import (
 	"github.com/spf13/viper"
 )
 
+// Config holds CLI configuration for API access.
 type Config struct {
 	APIURL        string
 	AdminPassword string
 }
 
+// bindConfig registers persistent CLI flags and environment variable bindings.
 func bindConfig(cmd *cobra.Command) {
 	flags := cmd.PersistentFlags()
 
@@ -26,6 +28,7 @@ func bindConfig(cmd *cobra.Command) {
 	_ = viper.BindPFlags(flags)
 }
 
+// loadConfig reads and validates configuration values from viper.
 func loadConfig() (*Config, error) {
 	cfg := &Config{
 		APIURL:        viper.GetString("api-url"),

--- a/internal/cli/notes/commands.go
+++ b/internal/cli/notes/commands.go
@@ -15,11 +15,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// editableNote is a YAML-serializable subset of note fields for interactive editing.
 type editableNote struct {
 	Title   string `yaml:"title"`
 	Content string `yaml:"content"`
 }
 
+// Register adds note CRUD subcommands to the CLI application.
 func Register(app *cli.App) {
 	getNoteCmd := &cobra.Command{
 		Use:   "note [id]",

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -11,6 +11,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// printTable writes key-value pairs as a tab-aligned table to stdout.
 func printTable(rows [][2]string) {
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 	for _, row := range rows {
@@ -19,6 +20,7 @@ func printTable(rows [][2]string) {
 	_ = w.Flush()
 }
 
+// printListTable writes a table with headers and rows to stdout.
 func printListTable(headers []string, rows [][]string) {
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 	for i, h := range headers {
@@ -40,6 +42,7 @@ func printListTable(headers []string, rows [][]string) {
 	_ = w.Flush()
 }
 
+// printYAML marshals a value as YAML and writes it to stdout.
 func printYAML(v any) error {
 	data, err := yaml.Marshal(v)
 	if err != nil {
@@ -49,6 +52,7 @@ func printYAML(v any) error {
 	return err
 }
 
+// printJSON marshals a value as indented JSON and writes it to stdout.
 func printJSON(v any) error {
 	data, err := json.MarshalIndent(v, "", "  ")
 	if err != nil {
@@ -58,6 +62,7 @@ func printJSON(v any) error {
 	return err
 }
 
+// PrintResource outputs a single resource in the configured format.
 func (a *App) PrintResource(v any, tableRows func() [][2]string) error {
 	switch a.OutputFormat {
 	case "yaml":
@@ -70,6 +75,7 @@ func (a *App) PrintResource(v any, tableRows func() [][2]string) error {
 	}
 }
 
+// PrintList outputs a list of resources in the configured format.
 func (a *App) PrintList(v any, headers []string, rowFn func() [][]string) error {
 	switch a.OutputFormat {
 	case "yaml":

--- a/internal/cli/parse.go
+++ b/internal/cli/parse.go
@@ -6,6 +6,7 @@ import (
 	"github.com/google/uuid"
 )
 
+// ParseID parses a string as a UUID, returning an error with context on failure.
 func ParseID(s string) (uuid.UUID, error) {
 	id, err := uuid.Parse(s)
 	if err != nil {

--- a/internal/cli/posts/commands.go
+++ b/internal/cli/posts/commands.go
@@ -16,11 +16,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// editablePost is a YAML-serializable subset of post fields for interactive editing.
 type editablePost struct {
 	Tags []string `yaml:"tags"`
 	Note string   `yaml:"note"`
 }
 
+// Register adds post CRUD subcommands to the CLI application.
 func Register(app *cli.App) {
 	var searchQuery string
 

--- a/internal/cli/replace/commands.go
+++ b/internal/cli/replace/commands.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// Register adds content and thumbnail replacement subcommands to the CLI application.
 func Register(app *cli.App) {
 	var contentFile string
 

--- a/internal/cli/tagcategories/commands.go
+++ b/internal/cli/tagcategories/commands.go
@@ -11,12 +11,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// editableTagCategory is a YAML-serializable subset of tag category fields for interactive editing.
 type editableTagCategory struct {
 	Name        string `yaml:"name"`
 	Description string `yaml:"description"`
 	Color       string `yaml:"color"`
 }
 
+// Register adds tag category CRUD subcommands to the CLI application.
 func Register(app *cli.App) {
 	getTagCategoryCmd := &cobra.Command{
 		Use:   "tagcategory [name]",

--- a/internal/cli/tags/commands.go
+++ b/internal/cli/tags/commands.go
@@ -11,14 +11,17 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// noCategoryLabel is the display label used when a tag has no category.
 const noCategoryLabel = "(none)"
 
+// editableTag is a YAML-serializable subset of tag fields for interactive editing.
 type editableTag struct {
 	Name        string  `yaml:"name"`
 	Category    *string `yaml:"category,omitempty"`
 	Description string  `yaml:"description"`
 }
 
+// Register adds tag CRUD subcommands to the CLI application.
 func Register(app *cli.App) {
 	getTagCmd := &cobra.Command{
 		Use:   "tag [name]",

--- a/internal/db/migrations/migrate.go
+++ b/internal/db/migrations/migrate.go
@@ -11,9 +11,12 @@ import (
 	"github.com/golang-migrate/migrate/v4/source/iofs"
 )
 
+// data is an embedded filesystem containing SQL migration files.
+//
 //go:embed data/*.sql
 var data embed.FS
 
+// Migrate runs all pending database migrations against the given DSN.
 func Migrate(dsn string) error {
 	migrationDriver, err := iofs.New(data, "data")
 	if err != nil {

--- a/internal/db/store/postgres.go
+++ b/internal/db/store/postgres.go
@@ -21,6 +21,7 @@ func NewPostgresSQLStore(db *sql.DB, similarityThreshold int) *PostgresSQLStore 
 	}
 }
 
+// Ping checks database connectivity.
 func (s *PostgresSQLStore) Ping(ctx context.Context) error {
 	return s.db.PingContext(ctx)
 }

--- a/internal/db/store/posts.go
+++ b/internal/db/store/posts.go
@@ -62,8 +62,10 @@ type UpdatePostContentInput struct {
 	UpdatedAt    time.Time
 }
 
+// postColumns is the SQL column list for post queries.
 const postColumns = "id, mime_type, content_url, thumbnail_url, note, has_audio, sha256, phash, created_at, updated_at"
 
+// scanPost scans a single row into a Post model.
 func scanPost(row interface{ Scan(...any) error }) (*models.Post, error) {
 	var p models.Post
 	err := row.Scan(&p.ID, &p.MimeType, &p.ContentURL, &p.ThumbnailURL, &p.Note, &p.HasAudio, &p.Sha256, &p.Phash, &p.CreatedAt, &p.UpdatedAt)
@@ -73,6 +75,7 @@ func scanPost(row interface{ Scan(...any) error }) (*models.Post, error) {
 	return &p, nil
 }
 
+// loadPostTags batch-loads tags for the given posts from the database.
 func loadPostTags(ctx context.Context, querier interface {
 	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
 }, posts ...*models.Post) error {

--- a/internal/db/store/store.go
+++ b/internal/db/store/store.go
@@ -6,7 +6,9 @@ import (
 )
 
 var (
-	ErrNotFound      = errors.New("not found")
+	// ErrNotFound is returned when a requested resource does not exist.
+	ErrNotFound = errors.New("not found")
+	// ErrAliasConflict is returned when an alias conflicts with an existing tag name.
 	ErrAliasConflict = errors.New("alias conflicts with existing tag name")
 )
 

--- a/internal/middleware/logging/httplog.go
+++ b/internal/middleware/logging/httplog.go
@@ -9,20 +9,25 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+// contextKey is a string type used for context value keys to avoid collisions.
 type contextKey string
 
+// requestIDKey is the context key for storing the request ID.
 const requestIDKey contextKey = "requestID"
 
+// statusWriter wraps http.ResponseWriter to capture the response status code.
 type statusWriter struct {
 	http.ResponseWriter
 	status int
 }
 
+// WriteHeader records the status code and delegates to the underlying ResponseWriter.
 func (w *statusWriter) WriteHeader(code int) {
 	w.status = code
 	w.ResponseWriter.WriteHeader(code)
 }
 
+// RequestLoggingMiddleware is HTTP middleware that assigns a request ID and logs each request.
 func RequestLoggingMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestID := r.Header.Get("X-Request-Id")

--- a/internal/search/query.go
+++ b/internal/search/query.go
@@ -2,6 +2,7 @@ package search
 
 import "github.com/dharmab/hyperboard/pkg/types"
 
+// Query represents parsed search parameters including tag filters, sort order, and type filters.
 type Query struct {
 	IncludedTags []types.TagName
 	ExcludedTags []types.TagName

--- a/internal/storage/memory/memory.go
+++ b/internal/storage/memory/memory.go
@@ -10,6 +10,7 @@ import (
 	"github.com/dharmab/hyperboard/internal/storage"
 )
 
+// entry holds stored data and content type for an in-memory object.
 type entry struct {
 	data        []byte
 	contentType string
@@ -26,10 +27,12 @@ func New() *Storage {
 	return &Storage{objects: make(map[string]entry)}
 }
 
+// Ping always returns nil (no-op connectivity check).
 func (s *Storage) Ping(_ context.Context) error {
 	return nil
 }
 
+// Upload stores data in memory and returns a fake URL.
 func (s *Storage) Upload(_ context.Context, key string, data []byte, contentType string) (string, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -37,6 +40,7 @@ func (s *Storage) Upload(_ context.Context, key string, data []byte, contentType
 	return "http://fake-storage/" + key, nil
 }
 
+// Download retrieves data from memory by key.
 func (s *Storage) Download(_ context.Context, key string) (*storage.Media, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -51,6 +55,7 @@ func (s *Storage) Download(_ context.Context, key string) (*storage.Media, error
 	}, nil
 }
 
+// Delete removes data from memory by key.
 func (s *Storage) Delete(_ context.Context, key string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/storage/s3/s3.go
+++ b/internal/storage/s3/s3.go
@@ -50,6 +50,7 @@ func New(ctx context.Context, endpoint, bucket, accessKey, secretKey, region str
 	return st, nil
 }
 
+// ensureBucketExists creates the configured S3 bucket if it does not already exist.
 func (st *Storage) ensureBucketExists(ctx context.Context) error {
 	_, err := st.client.HeadBucket(ctx, &s3.HeadBucketInput{
 		Bucket: aws.String(st.bucket),
@@ -77,6 +78,7 @@ func (st *Storage) ensureBucketExists(ctx context.Context) error {
 	return nil
 }
 
+// isNotFoundError checks whether an error represents an HTTP 404 response.
 func isNotFoundError(err error) bool {
 	// Fallback check for providers that return untyped 404 errors.
 	var respErr interface{ HTTPStatusCode() int }

--- a/internal/web/apiclient.go
+++ b/internal/web/apiclient.go
@@ -10,6 +10,7 @@ import (
 	"github.com/dharmab/hyperboard/pkg/client"
 )
 
+// newAPIClient creates an authenticated OpenAPI client for the Hyperboard API.
 func newAPIClient(baseURL, password string) (*client.ClientWithResponses, error) {
 	return client.NewClientWithResponses(
 		baseURL,
@@ -28,6 +29,7 @@ type mediaClient struct {
 	http     *http.Client
 }
 
+// newMediaClient creates an HTTP client for proxying media requests to the API.
 func newMediaClient(baseURL, password string) *mediaClient {
 	return &mediaClient{
 		baseURL:  baseURL,
@@ -36,6 +38,7 @@ func newMediaClient(baseURL, password string) *mediaClient {
 	}
 }
 
+// getRaw performs an authenticated GET request to the API.
 func (c *mediaClient) getRaw(ctx context.Context, path string) (*http.Response, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+path, nil)
 	if err != nil {
@@ -45,6 +48,7 @@ func (c *mediaClient) getRaw(ctx context.Context, path string) (*http.Response, 
 	return c.http.Do(req)
 }
 
+// head performs an authenticated HEAD request to the API.
 func (c *mediaClient) head(ctx context.Context, path string) (*http.Response, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodHead, c.baseURL+path, nil)
 	if err != nil {

--- a/internal/web/auth.go
+++ b/internal/web/auth.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 )
 
+// handleLogin serves the login page and processes login form submissions.
 func (a *app) handleLogin(w http.ResponseWriter, r *http.Request) {
 	if r.Method == http.MethodGet {
 		a.renderTemplate(w, r, "login.html", nil)
@@ -22,11 +23,13 @@ func (a *app) handleLogin(w http.ResponseWriter, r *http.Request) {
 	http.NotFound(w, r)
 }
 
+// handleLogout clears the session cookie and redirects to the login page.
 func (a *app) handleLogout(w http.ResponseWriter, r *http.Request) {
 	clearSessionCookie(w)
 	http.Redirect(w, r, "/login", http.StatusSeeOther)
 }
 
+// sessionMiddleware is HTTP middleware that requires a valid session cookie.
 func (a *app) sessionMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		cookie, err := r.Cookie(sessionCookieName)

--- a/internal/web/config.go
+++ b/internal/web/config.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/viper"
 )
 
+// config holds the configuration for the web frontend server.
 type config struct {
 	Port          string
 	AdminPassword string
@@ -18,6 +19,7 @@ type config struct {
 	TagFilters    []tagFilter
 }
 
+// bindConfig registers CLI flags and environment variable bindings.
 func bindConfig(cmd *cobra.Command) {
 	flags := cmd.Flags()
 
@@ -35,6 +37,7 @@ func bindConfig(cmd *cobra.Command) {
 	_ = viper.BindPFlags(flags)
 }
 
+// loadConfig reads and validates configuration values from viper.
 func loadConfig() (*config, error) {
 	tagFilters, err := parseTagFilters(viper.GetString("tag-filters"))
 	if err != nil {
@@ -50,6 +53,7 @@ func loadConfig() (*config, error) {
 	}, nil
 }
 
+// parseTagFilters parses a JSON string into a slice of tag filter definitions.
 func parseTagFilters(jsonStr string) ([]tagFilter, error) {
 	if jsonStr == "" {
 		return nil, nil

--- a/internal/web/markdown.go
+++ b/internal/web/markdown.go
@@ -8,6 +8,7 @@ import (
 	"github.com/yuin/goldmark"
 )
 
+// renderMarkdown converts a Markdown string to sanitized HTML.
 func renderMarkdown(src string) template.HTML {
 	var buf bytes.Buffer
 	if err := goldmark.Convert([]byte(src), &buf); err != nil {

--- a/internal/web/media.go
+++ b/internal/web/media.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 )
 
+// handleMedia proxies media requests to the API server.
 func (a *app) handleMedia(w http.ResponseWriter, r *http.Request) {
 	// /media/{key...} → proxy to API /media/{key...}
 	path := strings.TrimPrefix(r.URL.Path, "/media/")

--- a/internal/web/notes.go
+++ b/internal/web/notes.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 )
 
+// handleNotes serves the notes listing page and handles note creation.
 func (a *app) handleNotes(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
@@ -48,6 +49,7 @@ func (a *app) handleNotes(w http.ResponseWriter, r *http.Request) {
 	a.renderTemplate(w, r, "notes", notesData{Notes: notes, Error: loadErr})
 }
 
+// handleNote serves the single note view and handles note updates and deletion.
 func (a *app) handleNote(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	id := r.PathValue("id")

--- a/internal/web/posts.go
+++ b/internal/web/posts.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+// handlePosts serves the posts listing page with search and infinite scroll support.
 func (a *app) handlePosts(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	search := r.URL.Query().Get("search")
@@ -69,6 +70,7 @@ func (a *app) handlePosts(w http.ResponseWriter, r *http.Request) {
 	a.renderTemplate(w, r, "posts", data)
 }
 
+// handlePost serves the single post view and handles post deletion.
 func (a *app) handlePost(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	id := r.PathValue("id")

--- a/internal/web/routes.go
+++ b/internal/web/routes.go
@@ -15,6 +15,7 @@ func maxBody(limit int64, next http.HandlerFunc) http.HandlerFunc {
 	}
 }
 
+// registerRoutes registers all route handlers on the given ServeMux.
 func (a *app) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/", a.handlePosts)
 	mux.HandleFunc("/media/", a.handleMedia)

--- a/internal/web/session.go
+++ b/internal/web/session.go
@@ -11,7 +11,10 @@ import (
 	"time"
 )
 
+// sessionCookieName is the name of the HTTP cookie used for session tracking.
 const sessionCookieName = "session"
+
+// sessionExpiry is the duration before a session cookie expires.
 const sessionExpiry = 30 * 24 * time.Hour
 
 // signSession creates an HMAC-signed session token: base64(timestamp) + "." + base64(hmac)
@@ -51,6 +54,7 @@ func verifySession(secret, token string) bool {
 	return time.Since(time.Unix(ts, 0)) < sessionExpiry
 }
 
+// setSessionCookie creates and sets an HMAC-signed session cookie.
 func setSessionCookie(w http.ResponseWriter, secret string) {
 	token := signSession(secret)
 	http.SetCookie(w, &http.Cookie{
@@ -63,6 +67,7 @@ func setSessionCookie(w http.ResponseWriter, secret string) {
 	})
 }
 
+// clearSessionCookie removes the session cookie by setting MaxAge to -1.
 func clearSessionCookie(w http.ResponseWriter) {
 	http.SetCookie(w, &http.Cookie{
 		Name:     sessionCookieName,

--- a/internal/web/tagcategories.go
+++ b/internal/web/tagcategories.go
@@ -9,6 +9,7 @@ import (
 	"github.com/dharmab/hyperboard/pkg/types"
 )
 
+// handleTagCategories serves the tag categories listing page.
 func (a *app) handleTagCategories(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	var errs []string
@@ -34,6 +35,7 @@ func (a *app) handleTagCategories(w http.ResponseWriter, r *http.Request) {
 	a.renderTemplate(w, r, "tag_categories", tagCategoriesData{Categories: cats, TagCounts: tagCounts, Error: strings.Join(errs, "; ")})
 }
 
+// handleTagCategoryEdit serves the tag category edit form and handles creation, updates, and deletion.
 func (a *app) handleTagCategoryEdit(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	name := r.PathValue("name")

--- a/internal/web/tags.go
+++ b/internal/web/tags.go
@@ -9,6 +9,7 @@ import (
 	"github.com/dharmab/hyperboard/pkg/types"
 )
 
+// handleTags serves the tags listing page.
 func (a *app) handleTags(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
@@ -53,6 +54,7 @@ func (a *app) handleTags(w http.ResponseWriter, r *http.Request) {
 	a.renderTemplate(w, r, "tags", tagsData{Tags: allTags, CategoryColors: colorMap, Error: strings.Join(errs, "; ")})
 }
 
+// handleTagEdit serves the tag edit form and handles tag creation, updates, and deletion.
 func (a *app) handleTagEdit(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	name := r.PathValue("name")

--- a/internal/web/templatedata.go
+++ b/internal/web/templatedata.go
@@ -6,11 +6,13 @@ import (
 	"github.com/dharmab/hyperboard/pkg/types"
 )
 
+// tagFilter defines a labeled set of tag names for filter buttons in the UI.
 type tagFilter struct {
 	Label string   `json:"label"`
 	Tags  []string `json:"tags"`
 }
 
+// postsData holds template data for the posts listing page.
 type postsData struct {
 	Posts      []types.Post
 	NextCursor string
@@ -19,6 +21,7 @@ type postsData struct {
 	Error      string
 }
 
+// postData holds template data for the single post view page.
 type postData struct {
 	Post         types.Post
 	IsVideo      bool
@@ -27,12 +30,14 @@ type postData struct {
 	Error        string
 }
 
+// tagsData holds template data for the tags listing page.
 type tagsData struct {
 	Tags           []types.Tag
 	CategoryColors map[string]string
 	Error          string
 }
 
+// tagEditData holds template data for the tag edit form.
 type tagEditData struct {
 	Tag           types.Tag
 	Categories    []types.TagCategory
@@ -43,12 +48,14 @@ type tagEditData struct {
 	Error         string
 }
 
+// tagCategoriesData holds template data for the tag categories listing page.
 type tagCategoriesData struct {
 	Categories []types.TagCategory
 	TagCounts  map[string]int
 	Error      string
 }
 
+// tagCategoryEditData holds template data for the tag category edit form.
 type tagCategoryEditData struct {
 	Category    types.TagCategory
 	CurrentName string
@@ -56,11 +63,13 @@ type tagCategoryEditData struct {
 	Error       string
 }
 
+// notesData holds template data for the notes listing page.
 type notesData struct {
 	Notes []types.Note
 	Error string
 }
 
+// noteData holds template data for the single note view page.
 type noteData struct {
 	Note            types.Note
 	RenderedContent template.HTML

--- a/internal/web/templatefuncs.go
+++ b/internal/web/templatefuncs.go
@@ -8,8 +8,10 @@ import (
 	"strings"
 )
 
+// defaultColor is the CSS color value used when no category color is available.
 const defaultColor = "var(--base03)"
 
+// mediaPath extracts the URL path from a raw URL string, stripping scheme and host.
 func mediaPath(rawURL string) string {
 	u, err := url.Parse(rawURL)
 	if err != nil {
@@ -18,6 +20,7 @@ func mediaPath(rawURL string) string {
 	return strings.TrimRight(u.Path, "/")
 }
 
+// templateFuncs returns the FuncMap of custom template functions for HTML rendering.
 func templateFuncs() template.FuncMap {
 	return template.FuncMap{
 		"deref": func(s *string) string {

--- a/internal/web/upload.go
+++ b/internal/web/upload.go
@@ -19,6 +19,7 @@ type uploadConflict struct {
 	Body     []byte
 }
 
+// handleUpload serves the upload page and handles multipart file uploads.
 func (a *app) handleUpload(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	isXHR := r.Header.Get("X-Requested-With") == "XMLHttpRequest"

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -27,8 +27,10 @@ import (
 //go:embed templates static
 var embeddedFiles embed.FS
 
+// newResourceName is a sentinel path value indicating a new resource is being created.
 const newResourceName = "_new"
 
+// configPath is the path to the configuration file, set via CLI flag.
 var configPath string
 
 // NewCommand returns the cobra command for the hyperboard-web server.
@@ -44,6 +46,7 @@ func NewCommand() *cobra.Command {
 	return cmd
 }
 
+// initConfig reads the config file if configPath is set.
 func initConfig() {
 	if configPath != "" {
 		viper.SetConfigFile(configPath)
@@ -53,6 +56,7 @@ func initConfig() {
 	}
 }
 
+// app holds the web application state including configuration, API client, and templates.
 type app struct {
 	cfg   *config
 	api   *client.ClientWithResponses
@@ -60,6 +64,7 @@ type app struct {
 	tmpls map[string]*template.Template
 }
 
+// run initializes configuration, templates, and starts the web server.
 func run() error {
 	cfg, err := loadConfig()
 	if err != nil {


### PR DESCRIPTION
## Summary

- Add idiomatic GoDoc comments to all undocumented package-level symbols (types, functions, methods, constants, variables) across 47 non-generated Go files
- Covers `internal/api/`, `internal/cli/`, `internal/db/`, `internal/middleware/`, `internal/search/`, `internal/storage/`, and `internal/web/` packages
- Excludes generated files (`*.bob.go`, `gen.go`, OpenAPI spec), test files, struct fields, and `main` functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)