### PR TITLE
Fix htmx buttons missing hx-target="body"

### DIFF
--- a/internal/web/templates/post.html
+++ b/internal/web/templates/post.html
@@ -89,7 +89,8 @@ function setMediaMode(mode) {
 <div class="mt-2 flex gap-1">
   <button class="btn"
     hx-post="/posts/{{.Post.ID}}/regenerate-thumbnail"
-    hx-confirm="Regenerate thumbnail for this post?">Regenerate Thumbnail</button>
+    hx-confirm="Regenerate thumbnail for this post?"
+    hx-target="body">Regenerate Thumbnail</button>
   <button class="btn btn-danger"
     hx-delete="/posts/{{.Post.ID}}"
     hx-confirm="Delete this post?"

--- a/internal/web/templates/tag_category_edit.html
+++ b/internal/web/templates/tag_category_edit.html
@@ -23,6 +23,7 @@
   <button type="button" class="btn btn-danger"
     hx-delete="/tag-categories/{{.CurrentName}}"
     hx-confirm="Delete category {{.CurrentName}}?"
+    hx-target="body"
     hx-push-url="/tag-categories">Delete</button>
   {{end}}
 </form>

--- a/internal/web/templates/tag_edit.html
+++ b/internal/web/templates/tag_edit.html
@@ -38,6 +38,7 @@
   <button type="button" class="btn btn-danger"
     hx-delete="/tags/{{.CurrentName}}"
     hx-confirm="Delete tag {{.CurrentName}}?"
+    hx-target="body"
     hx-push-url="/tags">Delete</button>
   {{end}}
 </form>


### PR DESCRIPTION
## Summary
- Add `hx-target="body"` to three htmx buttons (delete tag, delete category, regenerate thumbnail) that trigger server redirects
- Without this attribute, htmx swaps the redirect response into the button element instead of replacing the whole page

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)