### PR TITLE
Set videos to loop by default

### DIFF
--- a/internal/web/templates/post.html
+++ b/internal/web/templates/post.html
@@ -12,7 +12,7 @@
 </div>
 <div class="post-media" id="post-media">
   {{if .IsVideo}}
-  <video controls src="{{.Post.ContentUrl | mediaUrl}}"></video>
+  <video controls loop src="{{.Post.ContentUrl | mediaUrl}}"></video>
   {{else}}
   <a href="{{.Post.ContentUrl | mediaUrl}}"><img src="{{.Post.ContentUrl | mediaUrl}}" alt="Post"></a>
   {{end}}


### PR DESCRIPTION
## Summary
- Add the `loop` attribute to the `<video>` element on the post page so videos automatically restart when they reach the end

Closes #44

## Test plan
- [ ] Open a video post and verify it loops when playback finishes

🤖 Generated with [Claude Code](https://claude.com/claude-code)