### PR TITLE
Remove fit/fill option from post page

### DIFF
--- a/internal/web/static/post.js
+++ b/internal/web/static/post.js
@@ -1,32 +1,3 @@
-function setMediaMode(mode) {
-  var el = document.getElementById('post-media');
-  var fitBtn = document.getElementById('media-mode-fit');
-  var fillBtn = document.getElementById('media-mode-fill');
-  if (mode === 'fill') {
-    el.classList.add('post-media--fill');
-    fillBtn.classList.add('media-mode-option--active');
-    fitBtn.classList.remove('media-mode-option--active');
-  } else {
-    el.classList.remove('post-media--fill');
-    fitBtn.classList.add('media-mode-option--active');
-    fillBtn.classList.remove('media-mode-option--active');
-  }
-  localStorage.setItem('mediaMode', mode);
-}
-
-(function() {
-  if (localStorage.getItem('mediaMode') === 'fill') {
-    setMediaMode('fill');
-  }
-})();
-
-document.getElementById('media-mode-fit').addEventListener('click', function() {
-  setMediaMode('fit');
-});
-document.getElementById('media-mode-fill').addEventListener('click', function() {
-  setMediaMode('fill');
-});
-
 // Note editor (only present when post has no note yet)
 (function() {
   var addNoteBtn = document.getElementById('btn-add-note');

--- a/internal/web/static/style.css
+++ b/internal/web/static/style.css
@@ -287,22 +287,13 @@ button:hover,
   color: inherit;
 }
 
-.media-mode-option {
+.text-btn {
   color: var(--base03);
   cursor: pointer;
 }
 
-.media-mode-option:hover {
+.text-btn:hover {
   color: var(--base04);
-}
-
-.media-mode-option--active {
-  color: var(--base05);
-  font-weight: 600;
-}
-
-.media-mode-sep {
-  color: var(--base03);
 }
 
 .post-media {
@@ -318,12 +309,6 @@ button:hover,
   border-radius: 6px;
 }
 
-.post-media.post-media--fill img,
-.post-media.post-media--fill video {
-  width: 100%;
-  max-height: 85vh;
-  object-fit: contain;
-}
 
 .post-tags {
   margin-bottom: 1rem;

--- a/internal/web/templates/post.html
+++ b/internal/web/templates/post.html
@@ -6,9 +6,6 @@
 {{if .Error}}<div class="alert-error">{{.Error}}</div>{{end}}
 <div class="post-media-controls">
   <span class="post-media-info">{{.Post.MimeType}}{{if .FileSize}} · <a href="{{.Post.ContentUrl | mediaUrl}}">{{.FileSize | formatSize}}</a>{{end}}</span>
-  <span id="media-mode-fit" class="media-mode-option media-mode-option--active">Fit</span>
-  <span class="media-mode-sep">/</span>
-  <span id="media-mode-fill" class="media-mode-option">Fill</span>
 </div>
 <div class="post-media" id="post-media">
   {{if .IsVideo}}
@@ -29,7 +26,7 @@
     <textarea id="note" name="note" rows="4" style="width:100%">{{.Post.Note}}</textarea>
   </form>
   {{else}}
-  <span class="media-mode-option" id="btn-add-note" style="cursor:pointer">+ Note</span>
+  <span class="text-btn" id="btn-add-note" style="cursor:pointer">+ Note</span>
   <template id="note-editor-tpl">
     <form hx-put="/posts/{{.Post.ID}}/note"
       hx-trigger="input changed delay:500ms"


### PR DESCRIPTION
## Summary
- Remove the Fit/Fill media mode toggle from the post page (default fitment works well in practice)
- Remove associated JavaScript (`setMediaMode`, localStorage handling, click listeners) and CSS (`.post-media--fill`)
- Rename leftover `media-mode-option` CSS class to `text-btn` and remove unused `--active` variant

Closes #48

## Test plan
- [ ] Open a post and verify the Fit/Fill toggle is gone
- [ ] Verify the media info line (MIME type, file size link) still displays correctly
- [ ] Verify the "+ Note" button still renders and functions correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)