### PR TITLE
Don't show similar posts for video posts

### DIFF
--- a/internal/web/posts.go
+++ b/internal/web/posts.go
@@ -101,17 +101,21 @@ func (a *app) handlePost(w http.ResponseWriter, r *http.Request) {
 			fileSize = headResp.ContentLength
 		}
 
+		isVideo := strings.HasPrefix(post.MimeType, "video/")
+
 		var similarPosts []types.Post
-		similarLimit := 12
-		if similarResp, err := a.api.GetSimilarPostsWithResponse(ctx, postID, &client.GetSimilarPostsParams{Limit: &similarLimit}); err == nil && similarResp.JSON200 != nil {
-			if similarResp.JSON200.Items != nil {
-				similarPosts = *similarResp.JSON200.Items
+		if !isVideo {
+			similarLimit := 12
+			if similarResp, err := a.api.GetSimilarPostsWithResponse(ctx, postID, &client.GetSimilarPostsParams{Limit: &similarLimit}); err == nil && similarResp.JSON200 != nil {
+				if similarResp.JSON200.Items != nil {
+					similarPosts = *similarResp.JSON200.Items
+				}
 			}
 		}
 
 		a.renderTemplate(w, r, "post", postData{
 			Post:         post,
-			IsVideo:      strings.HasPrefix(post.MimeType, "video/"),
+			IsVideo:      isVideo,
 			FileSize:     fileSize,
 			SimilarPosts: similarPosts,
 		})

--- a/internal/web/templates/post.html
+++ b/internal/web/templates/post.html
@@ -41,7 +41,7 @@
   {{end}}
 </div>
 
-{{if .SimilarPosts}}
+{{if and .SimilarPosts (not .IsVideo)}}
 <div class="mt-2">
   <h3>Similar Posts</h3>
   <div class="similar-posts-grid">


### PR DESCRIPTION
## Summary
- Skip the similar posts API call when viewing a video post
- Hide the similar posts section in the template for video posts

Closes #45

## Test plan
- [ ] Open a video post and verify no similar posts section is shown
- [ ] Open an image post and verify similar posts still display normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)