### PR TITLE
Replace datalist tag autocomplete with custom HTMX dropdown

### DIFF
--- a/internal/web/posts.go
+++ b/internal/web/posts.go
@@ -3,6 +3,7 @@ package web
 import (
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 
 	"github.com/dharmab/hyperboard/pkg/client"
@@ -279,14 +280,47 @@ func (a *app) handleTagSuggestions(w http.ResponseWriter, r *http.Request) {
 		cursor = resp.JSON200.Cursor
 	}
 
-	w.Header().Set("Content-Type", "text/html")
+	// Return empty response when query is empty
+	if q == "" {
+		w.Header().Set("Content-Type", "text/html")
+		return
+	}
+
+	// Filter and collect matching tags
+	var filtered []types.Tag
 	for _, tag := range allTags {
 		if excludeTags[tag.Name] {
 			continue
 		}
-		if q != "" && !strings.Contains(strings.ToLower(tag.Name), strings.ToLower(q)) {
+		if !strings.Contains(strings.ToLower(tag.Name), strings.ToLower(q)) {
 			continue
 		}
-		_, _ = fmt.Fprintf(w, "<option value=%q>", tag.Name)
+		filtered = append(filtered, tag)
+	}
+
+	// Sort by post count descending
+	sort.Slice(filtered, func(i, j int) bool {
+		ci, cj := 0, 0
+		if filtered[i].PostCount != nil {
+			ci = *filtered[i].PostCount
+		}
+		if filtered[j].PostCount != nil {
+			cj = *filtered[j].PostCount
+		}
+		return ci > cj
+	})
+
+	// Cap at 20 results
+	if len(filtered) > 20 {
+		filtered = filtered[:20]
+	}
+
+	w.Header().Set("Content-Type", "text/html")
+	for _, tag := range filtered {
+		count := 0
+		if tag.PostCount != nil {
+			count = *tag.PostCount
+		}
+		_, _ = fmt.Fprintf(w, `<div class="ac-item" data-value=%q>%s <span class="ac-count">(%d)</span></div>`, tag.Name, tag.Name, count)
 	}
 }

--- a/internal/web/posts_test.go
+++ b/internal/web/posts_test.go
@@ -184,10 +184,11 @@ func TestHandlePosts_WithoutTagFilters(t *testing.T) {
 func TestHandleTagSuggestions(t *testing.T) {
 	t.Parallel()
 	now := time.Now().UTC()
+	pc1, pc2, pc3 := 10, 5, 1
 	tags := []types.Tag{
-		{Name: "alpha", CreatedAt: now, UpdatedAt: now},
-		{Name: "beta", CreatedAt: now, UpdatedAt: now},
-		{Name: "gamma", CreatedAt: now, UpdatedAt: now},
+		{Name: "alpha", PostCount: &pc1, CreatedAt: now, UpdatedAt: now},
+		{Name: "apex", PostCount: &pc2, CreatedAt: now, UpdatedAt: now},
+		{Name: "zulu", PostCount: &pc3, CreatedAt: now, UpdatedAt: now},
 	}
 
 	app := newTestApp(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -198,7 +199,7 @@ func TestHandleTagSuggestions(t *testing.T) {
 		http.NotFound(w, r)
 	}))
 
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/tag-suggestions", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/tag-suggestions?q=a", nil)
 	w := httptest.NewRecorder()
 	app.handleTagSuggestions(w, req)
 
@@ -206,10 +207,13 @@ func TestHandleTagSuggestions(t *testing.T) {
 		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
 	}
 	body := w.Body.String()
-	for _, name := range []string{"alpha", "beta", "gamma"} {
-		if !strings.Contains(body, name) {
-			t.Errorf("expected %q in response body", name)
+	for _, name := range []string{"alpha", "apex"} {
+		if !strings.Contains(body, fmt.Sprintf(`data-value=%q`, name)) {
+			t.Errorf("expected ac-item with data-value %q in response body", name)
 		}
+	}
+	if strings.Contains(body, "zulu") {
+		t.Error("expected zulu to be filtered out by query")
 	}
 }
 
@@ -220,10 +224,11 @@ func TestHandleTagSuggestions_Pagination(t *testing.T) {
 	const totalTags = 3500
 	const pageSize = 1000
 
-	// Generate all tags
+	// Generate all tags with "tag-" prefix so they all match q=tag
 	allTags := make([]types.Tag, totalTags)
 	for i := range allTags {
-		allTags[i] = types.Tag{Name: fmt.Sprintf("tag-%04d", i), CreatedAt: now, UpdatedAt: now}
+		pc := totalTags - i
+		allTags[i] = types.Tag{Name: fmt.Sprintf("tag-%04d", i), PostCount: &pc, CreatedAt: now, UpdatedAt: now}
 	}
 
 	// Split into pages
@@ -253,7 +258,7 @@ func TestHandleTagSuggestions_Pagination(t *testing.T) {
 		http.NotFound(w, r)
 	}))
 
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/tag-suggestions", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/tag-suggestions?q=tag", nil)
 	w := httptest.NewRecorder()
 	app.handleTagSuggestions(w, req)
 
@@ -261,10 +266,10 @@ func TestHandleTagSuggestions_Pagination(t *testing.T) {
 		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
 	}
 	body := w.Body.String()
-	for _, tag := range allTags {
-		if !strings.Contains(body, fmt.Sprintf("value=%q", tag.Name)) {
-			t.Errorf("expected %q in response body", tag.Name)
-		}
+	// Results should be capped at 20
+	itemCount := strings.Count(body, "ac-item")
+	if itemCount != 20 {
+		t.Errorf("expected 20 ac-items, got %d", itemCount)
 	}
 	expectedCalls := len(pages)
 	if callCount != expectedCalls {
@@ -297,8 +302,8 @@ func TestHandleTagSuggestions_FilterByQuery(t *testing.T) {
 		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
 	}
 	body := w.Body.String()
-	if !strings.Contains(body, "alpha") {
-		t.Error("expected alpha in response")
+	if !strings.Contains(body, `data-value="alpha"`) {
+		t.Error("expected ac-item with alpha in response")
 	}
 	if strings.Contains(body, "beta") {
 		t.Error("expected beta to be filtered out")
@@ -321,7 +326,8 @@ func TestHandleTagSuggestions_ExcludeTags(t *testing.T) {
 		http.NotFound(w, r)
 	}))
 
-	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/tag-suggestions?exclude=alpha", nil)
+	// exclude=alpha, q=b so beta matches but alpha is excluded
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/tag-suggestions?exclude=alpha&q=b", nil)
 	w := httptest.NewRecorder()
 	app.handleTagSuggestions(w, req)
 
@@ -332,7 +338,103 @@ func TestHandleTagSuggestions_ExcludeTags(t *testing.T) {
 	if strings.Contains(body, "alpha") {
 		t.Error("expected alpha to be excluded")
 	}
-	if !strings.Contains(body, "beta") {
-		t.Error("expected beta in response")
+	if !strings.Contains(body, `data-value="beta"`) {
+		t.Error("expected ac-item with beta in response")
+	}
+}
+
+func TestHandleTagSuggestions_EmptyQuery(t *testing.T) {
+	t.Parallel()
+	now := time.Now().UTC()
+	tags := []types.Tag{
+		{Name: "alpha", CreatedAt: now, UpdatedAt: now},
+	}
+
+	app := newTestApp(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/api/v1/tags") {
+			jsonResponse(w, http.StatusOK, client.TagsResponse{Items: &tags})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/tag-suggestions", nil)
+	w := httptest.NewRecorder()
+	app.handleTagSuggestions(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	if w.Body.String() != "" {
+		t.Errorf("expected empty response for empty query, got %q", w.Body.String())
+	}
+}
+
+func TestHandleTagSuggestions_SortedByPostCount(t *testing.T) {
+	t.Parallel()
+	now := time.Now().UTC()
+	pc1, pc2, pc3 := 5, 100, 50
+	tags := []types.Tag{
+		{Name: "rare", PostCount: &pc1, CreatedAt: now, UpdatedAt: now},
+		{Name: "popular", PostCount: &pc2, CreatedAt: now, UpdatedAt: now},
+		{Name: "medium", PostCount: &pc3, CreatedAt: now, UpdatedAt: now},
+	}
+
+	app := newTestApp(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/api/v1/tags") {
+			jsonResponse(w, http.StatusOK, client.TagsResponse{Items: &tags})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+
+	// "popular" and "rare" both contain "a", "medium" does not
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/tag-suggestions?q=a", nil)
+	w := httptest.NewRecorder()
+	app.handleTagSuggestions(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	body := w.Body.String()
+	popIdx := strings.Index(body, "popular")
+	rareIdx := strings.Index(body, "rare")
+	if popIdx < 0 || rareIdx < 0 {
+		t.Fatalf("expected both popular and rare in response, got %q", body)
+	}
+	if popIdx > rareIdx {
+		t.Error("expected popular (100 posts) before rare (5 posts)")
+	}
+}
+
+func TestHandleTagSuggestions_CappedAt20(t *testing.T) {
+	t.Parallel()
+	now := time.Now().UTC()
+
+	tags := make([]types.Tag, 30)
+	for i := range tags {
+		pc := 30 - i
+		tags[i] = types.Tag{Name: fmt.Sprintf("atag-%02d", i), PostCount: &pc, CreatedAt: now, UpdatedAt: now}
+	}
+
+	app := newTestApp(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/api/v1/tags") {
+			jsonResponse(w, http.StatusOK, client.TagsResponse{Items: &tags})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/tag-suggestions?q=atag", nil)
+	w := httptest.NewRecorder()
+	app.handleTagSuggestions(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	body := w.Body.String()
+	itemCount := strings.Count(body, "ac-item")
+	if itemCount != 20 {
+		t.Errorf("expected 20 ac-items, got %d", itemCount)
 	}
 }

--- a/internal/web/static/autocomplete.js
+++ b/internal/web/static/autocomplete.js
@@ -1,0 +1,65 @@
+// Autocomplete keyboard navigation and selection for .ac-dropdown widgets
+(function() {
+  function getItems(dropdown) {
+    return dropdown.querySelectorAll('.ac-item');
+  }
+
+  function clearDropdown(dropdown) {
+    dropdown.innerHTML = '';
+  }
+
+  function selectItem(input, value) {
+    input.value = value;
+    input.dispatchEvent(new CustomEvent('ac-select', { bubbles: true, detail: { value: value } }));
+    var dropdown = input.parentElement.querySelector('.ac-dropdown');
+    if (dropdown) clearDropdown(dropdown);
+  }
+
+  document.body.addEventListener('keydown', function(e) {
+    var input = e.target;
+    if (input.tagName !== 'INPUT') return;
+    var dropdown = input.parentElement.querySelector('.ac-dropdown');
+    if (!dropdown) return;
+    var items = getItems(dropdown);
+    if (items.length === 0) return;
+
+    if (e.key === 'Tab') {
+      e.preventDefault();
+      var active = dropdown.querySelector('.ac-active');
+      if (active) {
+        active.classList.remove('ac-active');
+        var next = active.nextElementSibling || items[0];
+        next.classList.add('ac-active');
+        next.scrollIntoView({ block: 'nearest' });
+      } else {
+        items[0].classList.add('ac-active');
+        items[0].scrollIntoView({ block: 'nearest' });
+      }
+    } else if (e.key === 'Enter') {
+      var active = dropdown.querySelector('.ac-active');
+      if (active) {
+        e.preventDefault();
+        selectItem(input, active.dataset.value);
+      }
+    } else if (e.key === 'Escape') {
+      clearDropdown(dropdown);
+    }
+  });
+
+  document.body.addEventListener('click', function(e) {
+    var item = e.target.closest('.ac-item');
+    if (!item) return;
+    var dropdown = item.closest('.ac-dropdown');
+    if (!dropdown) return;
+    var input = dropdown.parentElement.querySelector('input');
+    if (input) selectItem(input, item.dataset.value);
+  });
+
+  document.body.addEventListener('focusout', function(e) {
+    var input = e.target;
+    if (input.tagName !== 'INPUT') return;
+    var dropdown = input.parentElement.querySelector('.ac-dropdown');
+    if (!dropdown) return;
+    setTimeout(function() { clearDropdown(dropdown); }, 150);
+  });
+})();

--- a/internal/web/static/post.js
+++ b/internal/web/static/post.js
@@ -12,15 +12,10 @@
   });
 })();
 
-// Tag input Enter key handling
-(function() {
+// Tag autocomplete selection: click the Add button
+document.addEventListener('ac-select', function(e) {
   var tagInput = document.getElementById('tag-input');
-  if (!tagInput) return;
-
-  tagInput.addEventListener('keydown', function(event) {
-    if (event.key === 'Enter') {
-      event.preventDefault();
-      this.closest('.post-tags-add').querySelector('button').click();
-    }
-  });
-})();
+  if (e.target === tagInput) {
+    tagInput.closest('.post-tags-add').querySelector('button').click();
+  }
+});

--- a/internal/web/static/posts.js
+++ b/internal/web/static/posts.js
@@ -77,40 +77,25 @@ document.querySelectorAll('.tag-filter-btn').forEach(function(btn) {
   btn.addEventListener('click', function() { cycleTagFilter(this); });
 });
 
-(function() {
-  var searchInput = document.getElementById('posts-search');
-  var datalist = document.getElementById('search-suggestions');
-  var debounceTimer;
+// Update random/filter buttons on input
+document.getElementById('posts-search').addEventListener('input', function() {
+  updateRandomButton();
+  updateTagFilterButtons();
+});
 
-  searchInput.addEventListener('input', function() {
-    updateRandomButton();
-    updateTagFilterButtons();
-    clearTimeout(debounceTimer);
-    var value = this.value;
-    var lastCommaIdx = value.lastIndexOf(',');
-    var lastWord = (lastCommaIdx >= 0 ? value.substring(lastCommaIdx + 1) : value).trim();
+// Extract last comma-separated term for autocomplete query
+document.getElementById('posts-search').addEventListener('htmx:configRequest', function(e) {
+  var value = this.value;
+  var lastComma = value.lastIndexOf(',');
+  var lastTerm = (lastComma >= 0 ? value.substring(lastComma + 1) : value).trim();
+  e.detail.parameters.q = lastTerm;
+});
 
-    if (!lastWord) {
-      datalist.innerHTML = '';
-      return;
-    }
-
-    debounceTimer = setTimeout(function() {
-      fetch('/tag-suggestions?q=' + encodeURIComponent(lastWord))
-        .then(function(r) { return r.text(); })
-        .then(function(html) {
-          if (lastCommaIdx >= 0) {
-            var prefix = value.substring(0, lastCommaIdx + 1) + ' ';
-            var temp = document.createElement('div');
-            temp.innerHTML = html;
-            temp.querySelectorAll('option').forEach(function(opt) {
-              opt.value = prefix + opt.value;
-            });
-            datalist.innerHTML = temp.innerHTML;
-          } else {
-            datalist.innerHTML = html;
-          }
-        });
-    }, 200);
-  });
-})();
+// Handle autocomplete selection: replace last term
+document.addEventListener('ac-select', function(e) {
+  var search = document.getElementById('posts-search');
+  if (e.target !== search) return;
+  var v = search.value;
+  var lastComma = v.lastIndexOf(',');
+  search.value = (lastComma >= 0 ? v.substring(0, lastComma + 1) + ' ' : '') + e.detail.value;
+});

--- a/internal/web/static/style.css
+++ b/internal/web/static/style.css
@@ -455,6 +455,15 @@ button:hover,
 .gap-2 { gap: 1rem; }
 .items-center { align-items: center; }
 
+/* Autocomplete */
+.ac-wrapper { position: relative; width: fit-content; }
+.ac-dropdown { position: absolute; top: 100%; left: 0; right: 0; z-index: 100;
+  background: var(--base01); border: 1px solid var(--base02); border-top: none;
+  border-radius: 0 0 4px 4px; max-height: 240px; overflow-y: auto; }
+.ac-item { padding: 0.4rem 0.75rem; cursor: pointer; color: var(--base05); }
+.ac-item.ac-active, .ac-item:hover { background: var(--base02); }
+.ac-count { color: var(--base03); font-size: 0.85em; margin-left: 0.25rem; }
+
 /* Mobile responsive */
 @media (max-width: 480px) {
   nav {

--- a/internal/web/templates/base.html
+++ b/internal/web/templates/base.html
@@ -25,6 +25,7 @@
 {{block "content" .}}{{end}}
 </main>
 <script src="/static/app.js"></script>
+<script src="/static/autocomplete.js"></script>
 </body>
 </html>
 {{end}}

--- a/internal/web/templates/post.html
+++ b/internal/web/templates/post.html
@@ -83,16 +83,15 @@
     {{end}}{{end}}
   </div>
   {{end}}
-  <div class="post-tags-add">
-    <input type="text" id="tag-input" placeholder="Add tag…" list="tag-suggestions"
+  <div class="ac-wrapper post-tags-add">
+    <input type="text" id="tag-input" placeholder="Add tag…"
       hx-get="/tag-suggestions?post={{$.Post.ID}}"
       hx-trigger="input changed delay:200ms"
-      hx-target="#tag-suggestions"
-      hx-include="this"
+      hx-target="next .ac-dropdown"
       name="q"
-      style="width:150px"
->
-    <datalist id="tag-suggestions"></datalist>
+      autocomplete="off"
+      style="width:150px">
+    <div class="ac-dropdown"></div>
     <button class="btn" hx-post="/posts/{{.Post.ID}}/tags" hx-include="#tag-input" hx-target=".post-tags" hx-swap="outerHTML">Add</button>
   </div>
 </div>

--- a/internal/web/templates/posts.html
+++ b/internal/web/templates/posts.html
@@ -5,10 +5,14 @@
 {{define "content"}}
 {{if .Error}}<div class="alert-error">{{.Error}}</div>{{end}}
 <form class="posts-controls" hx-get="/posts-partial" hx-push-url="true" hx-target="#posts-grid" hx-trigger="submit">
-  <input type="text" name="search" id="posts-search" placeholder="Search by tags (comma separated)…" value="{{.Search}}"
-    list="search-suggestions"
-    autocomplete="off">
-  <datalist id="search-suggestions"></datalist>
+  <div class="ac-wrapper" style="flex:1;min-width:200px">
+    <input type="text" name="search" id="posts-search" placeholder="Search by tags (comma separated)…" value="{{.Search}}"
+      hx-get="/tag-suggestions"
+      hx-trigger="input changed delay:200ms"
+      hx-target="next .ac-dropdown"
+      autocomplete="off">
+    <div class="ac-dropdown"></div>
+  </div>
   <button type="submit" class="btn btn-primary">Search</button>
   <button type="button" class="btn" id="btn-random">Random</button>
 </form>

--- a/internal/web/templates/tag_edit.html
+++ b/internal/web/templates/tag_edit.html
@@ -53,13 +53,15 @@
   data-confirm-message="Convert &quot;{{.CurrentName}}&quot; into an alias? This cannot be undone.">
   <div class="form-group" style="max-width:400px">
     <label>Target tag</label>
-    <input type="text" name="target" id="convert-target-input" required
-      list="convert-target-suggestions" placeholder="type to search…"
-      hx-get="/tag-suggestions?exclude={{.CurrentName}}"
-      hx-trigger="input changed delay:300ms"
-      hx-target="#convert-target-suggestions"
-      autocomplete="off">
-    <datalist id="convert-target-suggestions"></datalist>
+    <div class="ac-wrapper">
+      <input type="text" name="target" id="convert-target-input" required
+        placeholder="type to search…"
+        hx-get="/tag-suggestions?exclude={{.CurrentName}}"
+        hx-trigger="input changed delay:300ms"
+        hx-target="next .ac-dropdown"
+        autocomplete="off">
+      <div class="ac-dropdown"></div>
+    </div>
   </div>
   <button type="submit" class="btn btn-danger">Convert to Alias</button>
 </form>


### PR DESCRIPTION
## Summary

- Replace HTML `<datalist>` autocomplete with a custom HTMX-driven dropdown widget across post, search, and tag edit pages
- Add keyboard navigation (Tab to cycle, Enter to select, Escape to dismiss) via ~60 lines of vanilla JS using event delegation
- Sort suggestions by post count descending instead of lexically, cap results at 20, and require 1+ character before showing suggestions
- Fix broken Enter key after first tag add, mobile browser freezing from thousands of `<option>` elements, and missing Tab key support

Closes #42

## Test plan

- [ ] `make test` passes (3 new tests + 4 updated tests for the handler changes)
- [ ] `make lint` passes
- [ ] Manual test: post page tag input shows dropdown, Tab cycles, Enter selects, Escape dismisses
- [ ] Manual test: search page autocomplete replaces last comma-separated term on selection
- [ ] Manual test: tag edit page convert-to-alias autocomplete works
- [ ] Manual test on mobile: dropdown doesn't freeze browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)