### PR TITLE
Fix search autocomplete replacing entire input instead of appending tag

### DIFF
--- a/internal/web/static/autocomplete.js
+++ b/internal/web/static/autocomplete.js
@@ -9,8 +9,9 @@
   }
 
   function selectItem(input, value) {
+    var originalValue = input.value;
     input.value = value;
-    input.dispatchEvent(new CustomEvent('ac-select', { bubbles: true, detail: { value: value } }));
+    input.dispatchEvent(new CustomEvent('ac-select', { bubbles: true, detail: { value: value, originalValue: originalValue } }));
     var dropdown = input.parentElement.querySelector('.ac-dropdown');
     if (dropdown) clearDropdown(dropdown);
   }

--- a/internal/web/static/posts.js
+++ b/internal/web/static/posts.js
@@ -95,7 +95,7 @@ document.getElementById('posts-search').addEventListener('htmx:configRequest', f
 document.addEventListener('ac-select', function(e) {
   var search = document.getElementById('posts-search');
   if (e.target !== search) return;
-  var v = search.value;
+  var v = e.detail.originalValue;
   var lastComma = v.lastIndexOf(',');
   search.value = (lastComma >= 0 ? v.substring(0, lastComma + 1) + ' ' : '') + e.detail.value;
 });


### PR DESCRIPTION
## Summary
- When accepting an autocomplete suggestion in the posts search bar with multiple comma-separated tags, the entire input was replaced with just the selected tag (e.g. `tag1, ta` + selecting `tag2` → `tag2` instead of `tag1, tag2`)
- Root cause: `selectItem()` overwrites `input.value` before dispatching the `ac-select` event, so the handler in `posts.js` can no longer read the original value to reconstruct the input
- Fix: save the original input value and pass it via the `ac-select` event detail, then use `e.detail.originalValue` in the posts search handler

🤖 Generated with [Claude Code](https://claude.com/claude-code)