### PR TITLE
Add tag search with autocomplete and default desc sort

### DIFF
--- a/internal/web/static/table-sort.js
+++ b/internal/web/static/table-sort.js
@@ -7,7 +7,13 @@
       th.addEventListener('click', function() {
         var col = th.cellIndex;
         var type = th.dataset.type;
-        var asc = !th.classList.contains('sorted-asc');
+        var wasUnsorted = !th.classList.contains('sorted-asc') && !th.classList.contains('sorted-desc');
+        var asc;
+        if (wasUnsorted) {
+          asc = type !== 'number';
+        } else {
+          asc = !th.classList.contains('sorted-asc');
+        }
         headers.forEach(function(h) { h.classList.remove('sorted-asc', 'sorted-desc'); });
         th.classList.add(asc ? 'sorted-asc' : 'sorted-desc');
         var tbody = table.querySelector('tbody');

--- a/internal/web/static/tags-search.js
+++ b/internal/web/static/tags-search.js
@@ -1,0 +1,17 @@
+(function() {
+  var input = document.getElementById('tags-search');
+  var tbody = document.querySelector('#tags-table tbody');
+  function filterRows() {
+    var q = input.value.toLowerCase();
+    var rows = tbody.querySelectorAll('tr');
+    rows.forEach(function(row) {
+      var name = row.cells[0].dataset.value.toLowerCase();
+      row.style.display = name.includes(q) ? '' : 'none';
+    });
+  }
+  input.addEventListener('input', filterRows);
+  input.addEventListener('ac-select', function(e) {
+    input.value = e.detail.value;
+    filterRows();
+  });
+})();

--- a/internal/web/templates/tags.html
+++ b/internal/web/templates/tags.html
@@ -8,6 +8,19 @@
   <h1>Tags</h1>
   <a href="/tags/_new" class="btn btn-primary">New Tag</a>
 </div>
+<div class="ac-wrapper" style="margin-top:0.5rem">
+  <input
+    type="text"
+    name="q"
+    placeholder="Search tags…"
+    hx-get="/tag-suggestions"
+    hx-trigger="input changed delay:200ms"
+    hx-target="next .ac-dropdown"
+    autocomplete="off"
+    id="tags-search"
+  >
+  <div class="ac-dropdown"></div>
+</div>
 <table class="data-table mt-2" id="tags-table">
   <thead>
     <tr>
@@ -20,31 +33,9 @@
     </tr>
   </thead>
   <tbody>
-  {{range .Tags}}
-    <tr>
-      <td data-value="{{.Name}}">
-        <a href="/tags/{{.Name}}">{{.Name}}</a>
-      </td>
-      <td data-value="{{deref .Category}}">
-        {{if .Category}}<span class="badge" style="border-left-color: {{catColor $.CategoryColors .Category}}"><a href="/tag-categories/{{deref .Category}}" class="badge-link">{{deref .Category}}</a></span>{{end}}
-      </td>
-      <td data-value="{{.Description}}">{{.Description}}</td>
-      <td data-value="{{if .Aliases}}{{join_strings (deref_strings .Aliases) ", "}}{{end}}" style="color:var(--base03);font-size:0.9rem">
-        {{if .Aliases}}{{join_strings (deref_strings .Aliases) ", "}}{{end}}
-      </td>
-      <td data-value="{{if .CascadingTags}}{{join_strings (deref_strings .CascadingTags) ", "}}{{end}}" style="color:var(--base03);font-size:0.9rem">
-        {{if .CascadingTags}}{{join_strings (deref_strings .CascadingTags) ", "}}{{end}}
-      </td>
-      <td data-value="{{if .PostCount}}{{deref_int .PostCount}}{{else}}0{{end}}">
-        {{if and .PostCount (gt (deref_int .PostCount) 0)}}
-          <a href="/?search={{.Name}}">{{deref_int .PostCount}}</a>
-        {{else}}
-          0
-        {{end}}
-      </td>
-    </tr>
-  {{end}}
+  {{template "tags_rows" .}}
   </tbody>
 </table>
 <script src="/static/table-sort.js"></script>
+<script src="/static/tags-search.js"></script>
 {{end}}

--- a/internal/web/templates/tags_rows.html
+++ b/internal/web/templates/tags_rows.html
@@ -1,0 +1,26 @@
+{{define "tags_rows"}}
+{{range .Tags}}
+  <tr>
+    <td data-value="{{.Name}}">
+      <a href="/tags/{{.Name}}">{{.Name}}</a>
+    </td>
+    <td data-value="{{deref .Category}}">
+      {{if .Category}}<span class="badge" style="border-left-color: {{catColor $.CategoryColors .Category}}"><a href="/tag-categories/{{deref .Category}}" class="badge-link">{{deref .Category}}</a></span>{{end}}
+    </td>
+    <td data-value="{{.Description}}">{{.Description}}</td>
+    <td data-value="{{if .Aliases}}{{join_strings (deref_strings .Aliases) ", "}}{{end}}" style="color:var(--base03);font-size:0.9rem">
+      {{if .Aliases}}{{join_strings (deref_strings .Aliases) ", "}}{{end}}
+    </td>
+    <td data-value="{{if .CascadingTags}}{{join_strings (deref_strings .CascadingTags) ", "}}{{end}}" style="color:var(--base03);font-size:0.9rem">
+      {{if .CascadingTags}}{{join_strings (deref_strings .CascadingTags) ", "}}{{end}}
+    </td>
+    <td data-value="{{if .PostCount}}{{deref_int .PostCount}}{{else}}0{{end}}">
+      {{if and .PostCount (gt (deref_int .PostCount) 0)}}
+        <a href="/?search={{.Name}}">{{deref_int .PostCount}}</a>
+      {{else}}
+        0
+      {{end}}
+    </td>
+  </tr>
+{{end}}
+{{end}}

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -156,7 +156,6 @@ func parseTemplates() (map[string]*template.Template, error) {
 		"templates/posts.html",
 		"templates/post.html",
 		"templates/upload.html",
-		"templates/tags.html",
 		"templates/tag_edit.html",
 		"templates/tag_categories.html",
 		"templates/tag_category_edit.html",
@@ -164,10 +163,28 @@ func parseTemplates() (map[string]*template.Template, error) {
 		"templates/note.html",
 	}
 
+	// Templates that need additional partial templates
+	pagesWithPartials := map[string][]string{
+		"templates/tags.html": {"templates/tags_rows.html"},
+	}
+
 	tmpls := make(map[string]*template.Template)
 
 	for _, page := range pages {
 		t, err := template.New("").Funcs(funcs).ParseFS(embeddedFiles, base, page)
+		if err != nil {
+			return nil, fmt.Errorf("parsing %s: %w", page, err)
+		}
+		for _, dt := range t.Templates() {
+			if dt.Name() != "" {
+				tmpls[dt.Name()] = t
+			}
+		}
+	}
+
+	for page, partials := range pagesWithPartials {
+		files := append([]string{base, page}, partials...)
+		t, err := template.New("").Funcs(funcs).ParseFS(embeddedFiles, files...)
 		if err != nil {
 			return nil, fmt.Errorf("parsing %s: %w", page, err)
 		}


### PR DESCRIPTION
## Summary
- Add an active search input to the tags page with autocomplete suggestions from the existing `/tag-suggestions` endpoint and client-side row filtering
- Extract tag table rows into a reusable partial template (`tags_rows.html`)
- Default numeric table columns to descending sort on first click

🤖 Generated with [Claude Code](https://claude.com/claude-code)