### PR TITLE
Pre-fetch next page of images during infinite scroll

### DIFF
--- a/internal/web/posts.go
+++ b/internal/web/posts.go
@@ -23,6 +23,9 @@ func (a *app) handlePosts(w http.ResponseWriter, r *http.Request) {
 	cursor := r.URL.Query().Get("cursor")
 
 	limit := 24
+	if cursor != "" {
+		limit = 48
+	}
 	params := &client.GetPostsParams{Limit: &limit}
 	if search != "" {
 		params.Search = &search

--- a/internal/web/templates/posts.html
+++ b/internal/web/templates/posts.html
@@ -40,7 +40,7 @@
 {{end}}
 {{if .NextCursor}}
 <div hx-get="/posts-partial?cursor={{.NextCursor}}&search={{$.Search}}"
-     hx-trigger="revealed"
+     hx-trigger="intersect root-margin:0px 0px 100% 0px"
      hx-swap="outerHTML"
      hx-target="this">
 </div>


### PR DESCRIPTION
## Summary
- Double the page size for cursor-based scroll fetches (24 → 48) so more images are ready ahead of time
- Use HTMX's built-in `intersect` trigger with `root-margin` to start loading the next page one viewport height before the user reaches the sentinel element
- Removes the need for any custom JavaScript IntersectionObserver code

## Test plan
- [ ] Verify initial page load still fetches 24 posts
- [ ] Scroll down and confirm subsequent pages fetch 48 posts
- [ ] Confirm next page starts loading before the sentinel element is visible in the viewport
- [ ] Test with search filters active to ensure cursor + search params propagate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)