### PR TITLE
Add note that Hyperboard is considered completed software

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Hyperboard is a self-hosted image and video hosting website.
 
 ![](docs/images/screenshot-posts.webp)
 
+I consider Hyperboard to be completed software. I may add minor features to the CLI, but the webapp is feature complete.
+
 ## Who is Hyperboard for?
 
 It's for me. I made it:


### PR DESCRIPTION
## Summary
- Adds a note to the README stating that Hyperboard is considered completed software, with only minor CLI features potentially being added.

## Test plan
- [x] Verify README renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)