### PR TITLE
Replace gopkg.in/yaml.v3 with github.com/goccy/go-yaml

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.96.4
 	github.com/fergusstrange/embedded-postgres v1.26.0
 	github.com/gabriel-vasile/mimetype v1.4.9
+	github.com/goccy/go-yaml v1.19.2
 	github.com/gofrs/uuid/v5 v5.4.0
 	github.com/golang-migrate/migrate/v4 v4.18.3
 	github.com/google/uuid v1.6.0
@@ -22,7 +23,6 @@ require (
 	github.com/spf13/viper v1.21.0
 	github.com/yuin/goldmark v1.7.16
 	golang.org/x/image v0.36.0
-	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -399,6 +399,7 @@ require (
 	google.golang.org/protobuf v1.36.8 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	honnef.co/go/tools v0.7.0 // indirect
 	modernc.org/b v1.1.0 // indirect
 	modernc.org/db v1.0.15 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1064,6 +1064,8 @@ github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJA
 github.com/goccy/go-json v0.9.11/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/goccy/go-json v0.10.5 h1:Fq85nIqj+gXn/S5ahsiTlK3TmC85qgirsdTP/+DeaC4=
 github.com/goccy/go-json v0.10.5/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
+github.com/goccy/go-yaml v1.19.2 h1:PmFC1S6h8ljIz6gMRBopkjP1TVT7xuwrButHID66PoM=
+github.com/goccy/go-yaml v1.19.2/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
 github.com/gocql/gocql v1.7.0 h1:O+7U7/1gSN7QTEAaMEsJc1Oq2QHXvCWoF3DFK9HDHus=
 github.com/gocql/gocql v1.7.0/go.mod h1:vnlvXyFZeLBF0Wy+RS8hrOdbn0UWsWtdg07XJnFxZ+4=
 github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 h1:ZpnhV/YsD2/4cESfV5+Hoeu/iUR3ruzNvZ+yQfO03a0=

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -8,7 +8,7 @@ import (
 	"reflect"
 	"text/tabwriter"
 
-	"gopkg.in/yaml.v3"
+	"github.com/goccy/go-yaml"
 )
 
 // printTable writes key-value pairs as a tab-aligned table to stdout.

--- a/internal/cli/output_test.go
+++ b/internal/cli/output_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 
 	"github.com/dharmab/hyperboard/pkg/types"
+	"github.com/goccy/go-yaml"
 	"github.com/gofrs/uuid/v5"
-	"gopkg.in/yaml.v3"
 )
 
 func TestPrintJSON(t *testing.T) {


### PR DESCRIPTION
## Summary

- Replaces the unmaintained `gopkg.in/yaml.v3` direct dependency with `github.com/goccy/go-yaml`
- Updates imports in `internal/cli/output.go` and `internal/cli/output_test.go`
- `gopkg.in/yaml.v3` remains as an indirect dependency pulled in by other transitive deps

🤖 Generated with [Claude Code](https://claude.com/claude-code)