### PR TITLE
Remove delete confirmation pop-up on upload page

### DIFF
--- a/internal/web/static/upload.js
+++ b/internal/web/static/upload.js
@@ -193,7 +193,6 @@
     deleteBtn.className = 'btn btn-danger';
     deleteBtn.textContent = 'Delete this upload';
     deleteBtn.addEventListener('click', function() {
-      if (!confirm('Delete this upload?')) return;
       deleteBtn.disabled = true;
       fetch('/posts/' + postID, { method: 'DELETE' }).then(function(res) {
         if (res.ok) {


### PR DESCRIPTION
## Summary
- Removes the `confirm('Delete this upload?')` pop-up shown when deleting an upload flagged as having similar posts on the upload page — delete now happens immediately on click.

## Test plan
- [x] `make lint` passes
- [ ] Manually upload an image matching an existing post, click "Delete this upload" on the similar-posts panel, confirm it deletes immediately with no pop-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)