### PR TITLE
Surface specific API errors instead of generic failure messages

### DIFF
--- a/internal/api/tagcategories.go
+++ b/internal/api/tagcategories.go
@@ -139,6 +139,10 @@ func (s *Server) PutTagCategory(w http.ResponseWriter, r *http.Request, name Tag
 		Color:       req.Color,
 	}, now)
 	if err != nil {
+		if conflictErr, ok := errors.AsType[*store.TagCategoryNameConflictError](err); ok {
+			respondWithError(w, http.StatusBadRequest, "Tag category name %q already in use", conflictErr.Name)
+			return
+		}
 		respondWithError(w, http.StatusInternalServerError, "Failed to save tag category")
 		return
 	}

--- a/internal/api/tagcategories_integration_test.go
+++ b/internal/api/tagcategories_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/dharmab/hyperboard/pkg/types"
@@ -142,6 +143,38 @@ func TestTagCategoriesIntegration(t *testing.T) {
 		}
 		if cat.Description != "Updated description" {
 			t.Errorf("Description = %q, want %q", cat.Description, "Updated description")
+		}
+	})
+
+	t.Run("rename tag category to existing name returns bad request", func(t *testing.T) {
+		otherCatName := "test-category-other-" + uuid.Must(uuid.NewV4()).String()[:8]
+		otherBody := types.TagCategory{Name: otherCatName, Description: "Another category", Color: "#0000ff"}
+		ob, _ := json.Marshal(otherBody)
+		otherReq := httptest.NewRequestWithContext(t.Context(), http.MethodPut, "/api/v1/tagCategories/"+otherCatName, bytes.NewReader(ob))
+		otherReq.Header.Set("Content-Type", "application/json")
+		otherW := httptest.NewRecorder()
+		srv.PutTagCategory(otherW, otherReq, otherCatName)
+		if otherW.Code != http.StatusCreated {
+			t.Fatalf("PutTagCategory create status = %d, want %d; body = %s", otherW.Code, http.StatusCreated, otherW.Body.String())
+		}
+
+		body := types.TagCategory{Name: otherCatName, Description: "Renamed", Color: "#00ff00"}
+		b, _ := json.Marshal(body)
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodPut, "/api/v1/tagCategories/"+catName, bytes.NewReader(b))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		srv.PutTagCategory(w, req, catName)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("PutTagCategory rename to existing name status = %d, want %d; body = %s", w.Code, http.StatusBadRequest, w.Body.String())
+		}
+
+		var apiErr Error
+		if err := json.NewDecoder(w.Body).Decode(&apiErr); err != nil {
+			t.Fatalf("failed to decode error response: %v", err)
+		}
+		if !strings.Contains(apiErr.Message, otherCatName) {
+			t.Errorf("error message = %q, want it to mention %q", apiErr.Message, otherCatName)
 		}
 	})
 

--- a/internal/api/tags.go
+++ b/internal/api/tags.go
@@ -226,7 +226,6 @@ func (s *Server) PutTag(w http.ResponseWriter, r *http.Request, name Tag) {
 			respondWithError(w, http.StatusBadRequest, "Cascading tag %q does not exist", cascadeErr.Name)
 			return
 		}
-		logger.Error().Err(err).Msg("failed to save tag")
 		respondWithError(w, http.StatusInternalServerError, "Failed to save tag")
 		return
 	}

--- a/internal/api/tags.go
+++ b/internal/api/tags.go
@@ -222,6 +222,11 @@ func (s *Server) PutTag(w http.ResponseWriter, r *http.Request, name Tag) {
 			respondWithError(w, http.StatusInternalServerError, "Failed to update tag aliases")
 			return
 		}
+		if cascadeErr, ok := errors.AsType[*store.CascadeTargetNotFoundError](err); ok {
+			respondWithError(w, http.StatusBadRequest, "Cascading tag %q does not exist", cascadeErr.Name)
+			return
+		}
+		logger.Error().Err(err).Msg("failed to save tag")
 		respondWithError(w, http.StatusInternalServerError, "Failed to save tag")
 		return
 	}

--- a/internal/api/tags_integration_test.go
+++ b/internal/api/tags_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/dharmab/hyperboard/pkg/types"
@@ -226,6 +227,32 @@ func TestTagsIntegration(t *testing.T) {
 		}
 		if tag.Aliases == nil || len(*tag.Aliases) != 2 {
 			t.Errorf("expected 2 aliases, got %v", tag.Aliases)
+		}
+	})
+
+	t.Run("set cascading tag to nonexistent tag returns bad request", func(t *testing.T) {
+		missingName := "nonexistent-cascade-target-" + uuid.Must(uuid.NewV4()).String()[:8]
+		cascadingTags := []string{missingName}
+		body := types.Tag{
+			Name:          tagName,
+			CascadingTags: &cascadingTags,
+		}
+		b, _ := json.Marshal(body)
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodPut, "/api/v1/tags/"+tagName, bytes.NewReader(b))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		srv.PutTag(w, req, tagName)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("PutTag with missing cascade target status = %d, want %d; body = %s", w.Code, http.StatusBadRequest, w.Body.String())
+		}
+
+		var apiErr Error
+		if err := json.NewDecoder(w.Body).Decode(&apiErr); err != nil {
+			t.Fatalf("failed to decode error response: %v", err)
+		}
+		if !strings.Contains(apiErr.Message, missingName) {
+			t.Errorf("error message = %q, want it to mention %q", apiErr.Message, missingName)
 		}
 	})
 

--- a/internal/db/store/store.go
+++ b/internal/db/store/store.go
@@ -23,6 +23,17 @@ func (e *CascadeTargetNotFoundError) Error() string {
 	return fmt.Sprintf("cascade target tag %q not found", e.Name)
 }
 
+// TagCategoryNameConflictError is returned when creating or renaming a tag category to a name
+// already used by another tag category.
+type TagCategoryNameConflictError struct {
+	// Name is the conflicting tag category name.
+	Name string
+}
+
+func (e *TagCategoryNameConflictError) Error() string {
+	return fmt.Sprintf("tag category name %q already in use", e.Name)
+}
+
 // SQLStore combines all sub-interfaces for database operations.
 type SQLStore interface {
 	Pinger

--- a/internal/db/store/store.go
+++ b/internal/db/store/store.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"errors"
+	"fmt"
 )
 
 var (
@@ -11,6 +12,16 @@ var (
 	// ErrAliasConflict is returned when an alias conflicts with an existing tag name.
 	ErrAliasConflict = errors.New("alias conflicts with existing tag name")
 )
+
+// CascadeTargetNotFoundError is returned when a cascading tag reference does not resolve to an existing tag.
+type CascadeTargetNotFoundError struct {
+	// Name is the cascading tag reference as the caller supplied it (before alias resolution).
+	Name string
+}
+
+func (e *CascadeTargetNotFoundError) Error() string {
+	return fmt.Sprintf("cascade target tag %q not found", e.Name)
+}
 
 // SQLStore combines all sub-interfaces for database operations.
 type SQLStore interface {

--- a/internal/db/store/tagcategories.go
+++ b/internal/db/store/tagcategories.go
@@ -16,9 +16,16 @@ import (
 // pgUniqueViolationCode is the PostgreSQL SQLSTATE code for a unique constraint violation.
 const pgUniqueViolationCode = "23505"
 
-func isUniqueViolation(err error) bool {
+// tagCategoriesNameConstraint is the name Postgres assigns to the UNIQUE constraint on
+// tag_categories.name (table_column_key, its default naming convention).
+const tagCategoriesNameConstraint = "tag_categories_name_key"
+
+// isUniqueViolation reports whether err is a Postgres unique constraint violation of constraintName.
+// Checking the constraint name (not just the SQLSTATE code) keeps this correct if the table ever
+// gains another unique constraint.
+func isUniqueViolation(err error, constraintName string) bool {
 	pgErr, ok := errors.AsType[*pgconn.PgError](err)
-	return ok && pgErr.Code == pgUniqueViolationCode
+	return ok && pgErr.Code == pgUniqueViolationCode && pgErr.ConstraintName == constraintName
 }
 
 // TagCategoryStore provides CRUD operations for tag categories.
@@ -119,7 +126,7 @@ func (s *PostgresSQLStore) UpsertTagCategory(ctx context.Context, urlName string
 			input.Name, input.Description, input.Color, now, existing.ID,
 		)
 		if err != nil {
-			if isUniqueViolation(err) {
+			if isUniqueViolation(err, tagCategoriesNameConstraint) {
 				return nil, false, &TagCategoryNameConflictError{Name: input.Name}
 			}
 			return nil, false, err
@@ -141,7 +148,7 @@ func (s *PostgresSQLStore) UpsertTagCategory(ctx context.Context, urlName string
 		input.Name, input.Description, input.Color, now, now,
 	).Scan(&inserted.ID, &inserted.Name, &inserted.Description, &inserted.Color, &inserted.CreatedAt, &inserted.UpdatedAt)
 	if err != nil {
-		if isUniqueViolation(err) {
+		if isUniqueViolation(err, tagCategoriesNameConstraint) {
 			return nil, false, &TagCategoryNameConflictError{Name: input.Name}
 		}
 		return nil, false, err

--- a/internal/db/store/tagcategories.go
+++ b/internal/db/store/tagcategories.go
@@ -10,7 +10,16 @@ import (
 
 	"github.com/dharmab/hyperboard/internal/db/models"
 	"github.com/gofrs/uuid/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 )
+
+// pgUniqueViolationCode is the PostgreSQL SQLSTATE code for a unique constraint violation.
+const pgUniqueViolationCode = "23505"
+
+func isUniqueViolation(err error) bool {
+	pgErr, ok := errors.AsType[*pgconn.PgError](err)
+	return ok && pgErr.Code == pgUniqueViolationCode
+}
 
 // TagCategoryStore provides CRUD operations for tag categories.
 type TagCategoryStore interface {
@@ -110,6 +119,9 @@ func (s *PostgresSQLStore) UpsertTagCategory(ctx context.Context, urlName string
 			input.Name, input.Description, input.Color, now, existing.ID,
 		)
 		if err != nil {
+			if isUniqueViolation(err) {
+				return nil, false, &TagCategoryNameConflictError{Name: input.Name}
+			}
 			return nil, false, err
 		}
 		existing.Name = input.Name
@@ -129,6 +141,9 @@ func (s *PostgresSQLStore) UpsertTagCategory(ctx context.Context, urlName string
 		input.Name, input.Description, input.Color, now, now,
 	).Scan(&inserted.ID, &inserted.Name, &inserted.Description, &inserted.Color, &inserted.CreatedAt, &inserted.UpdatedAt)
 	if err != nil {
+		if isUniqueViolation(err) {
+			return nil, false, &TagCategoryNameConflictError{Name: input.Name}
+		}
 		return nil, false, err
 	}
 

--- a/internal/db/store/tags.go
+++ b/internal/db/store/tags.go
@@ -464,7 +464,7 @@ func (s *PostgresSQLStore) setTagCascades(ctx context.Context, tx *sql.Tx, tagID
 		err = tx.QueryRowContext(ctx, "SELECT id FROM tags WHERE name = $1", resolved).Scan(&targetID)
 		if err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
-				return fmt.Errorf("cascade target tag %q not found", name)
+				return &CascadeTargetNotFoundError{Name: name}
 			}
 			return err
 		}

--- a/internal/web/helpers_test.go
+++ b/internal/web/helpers_test.go
@@ -31,6 +31,7 @@ func newTestApp(t *testing.T, handler http.Handler) *app {
 }
 
 const postsAPIPath = "/api/v1/posts"
+const notesAPIPath = "/api/v1/notes"
 
 func jsonResponse(w http.ResponseWriter, status int, v any) {
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/web/notes.go
+++ b/internal/web/notes.go
@@ -24,9 +24,11 @@ func (a *app) handleNotes(w http.ResponseWriter, r *http.Request) {
 			if notesResp != nil && notesResp.JSON200 != nil && notesResp.JSON200.Items != nil {
 				notes = *notesResp.JSON200.Items
 			}
-			errMsg := "Failed to create note"
+			var errMsg string
 			if err != nil {
 				errMsg = fmt.Sprintf("Failed to create note: %v", err)
+			} else {
+				errMsg = fmt.Sprintf("Failed to create note: %s", resp.Body)
 			}
 			a.renderTemplate(w, r, "notes", notesData{Notes: notes, Error: errMsg})
 			return
@@ -87,8 +89,12 @@ func (a *app) handleNote(w http.ResponseWriter, r *http.Request) {
 			Title:   r.FormValue("title"),
 			Content: r.FormValue("content"),
 		})
-		if err != nil || resp.StatusCode() >= 400 {
-			http.Error(w, "Failed to save note", http.StatusInternalServerError)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("Failed to save note: %v", err), http.StatusInternalServerError)
+			return
+		}
+		if resp.StatusCode() >= 400 {
+			http.Error(w, fmt.Sprintf("Failed to save note: %s", resp.Body), resp.StatusCode())
 			return
 		}
 		// Return rendered markdown for HTMX swap

--- a/internal/web/notes_test.go
+++ b/internal/web/notes_test.go
@@ -19,7 +19,7 @@ func TestHandleNotes_GET(t *testing.T) {
 	notes := []types.Note{{ID: noteID, Title: "Test Note", CreatedAt: now, UpdatedAt: now}}
 
 	app := newTestApp(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/api/v1/notes" {
+		if r.URL.Path == notesAPIPath {
 			jsonResponse(w, http.StatusOK, client.NotesResponse{Items: &notes})
 			return
 		}
@@ -44,7 +44,7 @@ func TestHandleNotes_POST(t *testing.T) {
 	now := time.Now().UTC()
 
 	app := newTestApp(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodPost && r.URL.Path == "/api/v1/notes" {
+		if r.Method == http.MethodPost && r.URL.Path == notesAPIPath {
 			jsonResponse(w, http.StatusCreated, types.Note{ID: createdID, Title: "New Note", CreatedAt: now, UpdatedAt: now})
 			return
 		}
@@ -61,5 +61,58 @@ func TestHandleNotes_POST(t *testing.T) {
 	loc := w.Header().Get("Location")
 	if !strings.Contains(loc, createdID.String()) {
 		t.Errorf("redirect location = %q, want it to contain %s", loc, createdID)
+	}
+}
+
+func TestHandleNotes_POST_APIError(t *testing.T) {
+	t.Parallel()
+
+	app := newTestApp(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == notesAPIPath:
+			jsonResponse(w, http.StatusBadRequest, map[string]string{"message": "Too many notes"})
+		case r.Method == http.MethodGet && r.URL.Path == notesAPIPath:
+			jsonResponse(w, http.StatusOK, client.NotesResponse{})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/notes", nil)
+	w := httptest.NewRecorder()
+	app.handleNotes(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (template render with error); body = %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "Too many notes") {
+		t.Errorf("expected error body to contain API message, got %q", w.Body.String())
+	}
+}
+
+func TestHandleNote_PUT_APIError(t *testing.T) {
+	t.Parallel()
+	noteID := types.ID(uuid.Must(uuid.NewV4()))
+
+	app := newTestApp(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut && strings.HasPrefix(r.URL.Path, "/api/v1/notes/") {
+			jsonResponse(w, http.StatusBadRequest, map[string]string{"message": "Title is required"})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+
+	form := strings.NewReader("title=&content=hello")
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPut, "/notes/"+noteID.String(), form)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetPathValue("id", noteID.String())
+	w := httptest.NewRecorder()
+	app.handleNote(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body = %s", w.Code, http.StatusBadRequest, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "Title is required") {
+		t.Errorf("expected error body to contain API message, got %q", w.Body.String())
 	}
 }

--- a/internal/web/posts.go
+++ b/internal/web/posts.go
@@ -164,8 +164,12 @@ func (a *app) handlePostNote(w http.ResponseWriter, r *http.Request) {
 	post := *resp.JSON200
 	post.Note = note
 	putResp, err := a.api.PutPostWithResponse(ctx, postID, post)
-	if err != nil || putResp.StatusCode() >= 400 {
-		http.Error(w, "Failed to save note", http.StatusInternalServerError)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Failed to save note: %v", err), http.StatusInternalServerError)
+		return
+	}
+	if putResp.StatusCode() >= 400 {
+		http.Error(w, fmt.Sprintf("Failed to save note: %s", putResp.Body), putResp.StatusCode())
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
@@ -193,8 +197,12 @@ func (a *app) handlePostTags(w http.ResponseWriter, r *http.Request) {
 		if tagName != "" {
 			post.Tags = append(post.Tags, tagName)
 			putResp, err := a.api.PutPostWithResponse(ctx, postID, post)
-			if err != nil || putResp.StatusCode() >= 400 {
-				http.Error(w, "Failed to add tag", http.StatusInternalServerError)
+			if err != nil {
+				http.Error(w, fmt.Sprintf("Failed to add tag: %v", err), http.StatusInternalServerError)
+				return
+			}
+			if putResp.StatusCode() >= 400 {
+				http.Error(w, fmt.Sprintf("Failed to add tag: %s", putResp.Body), putResp.StatusCode())
 				return
 			}
 		}
@@ -208,8 +216,12 @@ func (a *app) handlePostTags(w http.ResponseWriter, r *http.Request) {
 		}
 		post.Tags = newTags
 		putResp, err := a.api.PutPostWithResponse(ctx, postID, post)
-		if err != nil || putResp.StatusCode() >= 400 {
-			http.Error(w, "Failed to remove tag", http.StatusInternalServerError)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("Failed to remove tag: %v", err), http.StatusInternalServerError)
+			return
+		}
+		if putResp.StatusCode() >= 400 {
+			http.Error(w, fmt.Sprintf("Failed to remove tag: %s", putResp.Body), putResp.StatusCode())
 			return
 		}
 	}

--- a/internal/web/posts_test.go
+++ b/internal/web/posts_test.go
@@ -184,6 +184,70 @@ func TestHandlePosts_WithoutTagFilters(t *testing.T) {
 	}
 }
 
+func TestHandlePostNote_APIError(t *testing.T) {
+	t.Parallel()
+	postID := types.ID(uuid.Must(uuid.NewV4()))
+	now := time.Now().UTC()
+	post := types.Post{ID: postID, MimeType: "image/webp", CreatedAt: now, UpdatedAt: now}
+
+	app := newTestApp(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/api/v1/posts/"):
+			jsonResponse(w, http.StatusOK, post)
+		case r.Method == http.MethodPut && strings.HasPrefix(r.URL.Path, "/api/v1/posts/"):
+			jsonResponse(w, http.StatusBadRequest, map[string]string{"message": "Note is too long"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+
+	form := strings.NewReader("note=hello")
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/posts/"+postID.String()+"/note", form)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetPathValue("id", postID.String())
+	w := httptest.NewRecorder()
+	app.handlePostNote(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body = %s", w.Code, http.StatusBadRequest, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "Note is too long") {
+		t.Errorf("expected error body to contain API message, got %q", w.Body.String())
+	}
+}
+
+func TestHandlePostTags_AddAPIError(t *testing.T) {
+	t.Parallel()
+	postID := types.ID(uuid.Must(uuid.NewV4()))
+	now := time.Now().UTC()
+	post := types.Post{ID: postID, MimeType: "image/webp", CreatedAt: now, UpdatedAt: now}
+
+	app := newTestApp(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/api/v1/posts/"):
+			jsonResponse(w, http.StatusOK, post)
+		case r.Method == http.MethodPut && strings.HasPrefix(r.URL.Path, "/api/v1/posts/"):
+			jsonResponse(w, http.StatusBadRequest, map[string]string{"message": "Tag name is invalid"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+
+	form := strings.NewReader("q=!!!invalid")
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/posts/"+postID.String()+"/tags", form)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetPathValue("id", postID.String())
+	w := httptest.NewRecorder()
+	app.handlePostTags(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body = %s", w.Code, http.StatusBadRequest, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "Tag name is invalid") {
+		t.Errorf("expected error body to contain API message, got %q", w.Body.String())
+	}
+}
+
 func TestHandleTagSuggestions(t *testing.T) {
 	t.Parallel()
 	now := time.Now().UTC()


### PR DESCRIPTION
## Summary
- Fixes #73: saving a tag with a cascading-tag reference to a nonexistent tag showed the unhelpful `Failed to save tag: {"message":"Failed to save tag"}` instead of explaining the actual cause.
- While auditing the codebase for this failure mode (a specific error computed somewhere in the stack, then discarded in favor of a generic "Failed to X" message), found and fixed several structurally identical spots:
  - `internal/api/tags.go` `PutTag` only special-cased `store.ErrAliasConflict`; every other error from `UpsertTag` fell through to a generic 500. The store already produced a specific message for a missing cascade target — it just never reached the response. Wrapped it in a typed `store.CascadeTargetNotFoundError` and added a 400 response naming the missing tag.
  - `internal/web/posts.go` — adding/removing a tag on a post, and saving a post's note, discarded the API response body on failure, always showing a generic "Failed to add/remove/save" message. Now forwards the API's actual error and status code.
  - `internal/web/notes.go` — saving a note's title/content (and the sibling create-note path) showed a hardcoded "Failed to save/create note" even for a 400 like "Title is required" that the API already returns with a clear reason. Now forwards the API's error.
  - `internal/db/store/tagcategories.go` — renaming or creating a tag category with a name already in use hit a raw unique-constraint error with no translation. Added detection of the Postgres unique-violation SQLSTATE and a typed `store.TagCategoryNameConflictError`, surfaced by the API as 400 with the conflicting name.

## Test plan
- [x] `make test` (full suite, including new integration/unit tests for each fixed path)
- [x] `make lint`
- [ ] Manually verify in the web UI: edit an existing tag, add a cascading tag name that doesn't exist, save, and confirm the error message names the missing tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)